### PR TITLE
Load Alpine.js from CDN in Jetstream layouts

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,6 +13,7 @@
 
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>
 
     <!-- Styles -->
     @livewireStyles

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -13,6 +13,7 @@
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+        <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>
 
         <!-- Styles -->
         @livewireStyles


### PR DESCRIPTION
## Summary
- load Alpine.js from a CDN in the guest layout so registration/login pages have access to Alpine directives
- include the same CDN script in the app layout to restore Alpine-driven Jetstream components across authenticated pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17ac9cb58832785f38555e96532fc