### PR TITLE
Integrate dynamic menu sidebar into dashboard

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -5,6 +5,26 @@
         </h2>
     </x-slot>
 
+    @php
+        $menuTree = app(\App\Services\MenuBuilder::class)->buildForCurrentUser();
+    @endphp
+
+    <x-slot name="sidebar">
+        <div class="p-4 space-y-4">
+            <p class="text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                {{ __('Menú principal') }}
+            </p>
+
+            @if (count($menuTree) > 0)
+                <x-sidebar-menu :menus="$menuTree" />
+            @else
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                    {{ __('Todavía no tienes accesos asignados.') }}
+                </p>
+            @endif
+        </div>
+    </x-slot>
+
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,6 +13,7 @@
 
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>
 
     <!-- Styles -->
     @livewireStyles
@@ -24,41 +25,46 @@
     {{-- Header Jetstream fijo arriba (≈ h-16) --}}
     @livewire('navigation-menu')
 
+    @php
+        $hasSidebar = isset($sidebar) && $sidebar instanceof \Illuminate\View\ComponentSlot && ! $sidebar->isEmpty();
+    @endphp
+
     {{-- Backdrop para el drawer móvil --}}
-    <div
-        x-show="sidebarOpen"
-        x-transition.opacity
-        @click="sidebarOpen = false"
-        class="fixed inset-0 z-30 bg-black/40 md:hidden"></div>
+    @if ($hasSidebar)
+        <div
+            x-cloak
+            x-show="sidebarOpen"
+            x-transition.opacity
+            @click="sidebarOpen = false"
+            class="fixed inset-0 z-30 bg-black/40 md:hidden"></div>
+    @endif
 
     {{-- Contenedor principal empujado debajo del header --}}
-    <div class="pt-16">
-        <div class="flex">
+    <div class="min-h-screen pt-16">
+        <div @class(['flex' => $hasSidebar])>
 
             {{-- Sidebar fijo: debajo del header, con drawer móvil --}}
-            <aside
-                class="fixed top-16 left-0 z-40 w-64 h-[calc(100vh-4rem)] overflow-y-auto
-                       bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700
-                       transform transition-transform duration-200 ease-in-out
-                       md:translate-x-0"
-                :class="sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'">
-
-                <div class="p-4">
-                    @php
-                        $menus = app(\App\Services\MenuBuilder::class)->buildForCurrentUser();
-                    @endphp
-                    <x-sidebar-menu :menus="$menus"/>
-                </div>
-            </aside>
+            @if ($hasSidebar)
+                <aside
+                    class="fixed top-16 left-0 z-40 w-64 h-[calc(100vh-4rem)] overflow-y-auto
+                           bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700
+                           transform transition-transform duration-200 ease-in-out
+                           md:translate-x-0"
+                    :class="sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'">
+                    {{ $sidebar }}
+                </aside>
+            @endif
 
             {{-- Contenido principal (margen para el aside en md+) --}}
-            <div class="flex-1 md:ml-64 w-full">
+            <div @class(['w-full', 'flex-1 md:ml-64' => $hasSidebar])>
                 {{-- Top bar opcional (solo si quieres un botón hamburguesa adicional) --}}
-                <div class="md:hidden bg-white dark:bg-gray-800 shadow px-4 py-2">
-                    <button @click="sidebarOpen = !sidebarOpen" class="text-gray-600 dark:text-gray-300">
-                        <i class="fas fa-bars"></i>
-                    </button>
-                </div>
+                @if ($hasSidebar)
+                    <div class="md:hidden bg-white dark:bg-gray-800 shadow px-4 py-2">
+                        <button @click="sidebarOpen = !sidebarOpen" class="text-gray-600 dark:text-gray-300">
+                            <i class="fas fa-bars"></i>
+                        </button>
+                    </div>
+                @endif
 
                 {{-- Header opcional de página --}}
                 @if (isset($header))
@@ -77,6 +83,7 @@
         </div>
     </div>
     <script src="https://kit.fontawesome.com/8ce750f5df.js" crossorigin="anonymous"></script>
+    @stack('modals')
     @livewireScripts
 </body>
 </html>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -13,6 +13,7 @@
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+        <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>
 
         <!-- Styles -->
         @livewireStyles


### PR DESCRIPTION
## Summary
- make the Jetstream app layout render an optional sidebar slot and mobile drawer only when sidebar content is provided
- populate the dashboard sidebar slot with the menu tree built by MenuBuilder so authenticated users see their dynamic navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d17ac9cb58832785f38555e96532fc