### PR TITLE
Deduplicate register roles and make seeders idempotent

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -23,6 +23,8 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
+        $registerableRoles = config('roles.registerable', []);
+
         $validated = Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => [
@@ -36,28 +38,22 @@ class CreateNewUser implements CreatesNewUsers
             ],
             'password' => $this->passwordRules(),
 
-            'role' => ['required', Rule::in([
-                'manager',
-                'director',
-                'teamLead',
-                'teamCoordinator',
-                'teamMember'
-            ])],
+            'role' => ['required', Rule::in($registerableRoles)],
 
             'position'      => ['required', 'string', 'max:100'],
             'supervisor_id' => ['nullable', 'exists:users,id'],
             'area_id'       => ['required', 'exists:areas,id'],
 
-            // Subdepartment requerido excepto para manager
+            // Subdepartment requerido excepto para manager y administrator
             'subdepartment_id' => [
-                Rule::requiredIf(fn () => $input['role'] !== 'manager'),
+                Rule::requiredIf(fn () => ! in_array($input['role'], ['manager', 'administrator'])),
                 'nullable',
                 'exists:subdepartments,id',
             ],
 
-            // Team requerido excepto para manager y director
+            // Team requerido excepto para manager, director y administrator
             'team_id' => [
-                Rule::requiredIf(fn () => ! in_array($input['role'], ['manager', 'director'])),
+                Rule::requiredIf(fn () => ! in_array($input['role'], ['manager', 'director', 'administrator'])),
                 'nullable',
                 'exists:teams,id',
             ],

--- a/config/roles.php
+++ b/config/roles.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'registerable' => [
+        'administrator',
+        'manager',
+        'director',
+        'teamLead',
+        'teamCoordinator',
+        'teamMember',
+    ],
+];

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Menu;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
 class MenuSeeder extends Seeder
@@ -38,12 +39,43 @@ class MenuSeeder extends Seeder
         );
 
         // Asociar roles
-        $roles = ['manager', 'director', 'teamLead', 'teamCoordinator', 'teamMember'];
-        foreach ($roles as $roleName) {
-            $role = Role::where('name', $roleName)->first();
-            if ($role) {
-                $comunicados->roles()->syncWithoutDetaching([$role->id]);
+        $roleNames = config('roles.registerable', []);
+        $roles = Role::query()
+            ->where('guard_name', 'web')
+            ->whereIn('name', $roleNames)
+            ->get()
+            ->unique('name')
+            ->keyBy('name');
+
+        $permission = $comunicados->permission
+            ? Permission::firstOrCreate([
+                'name' => $comunicados->permission,
+                'guard_name' => 'web',
+            ])
+            : null;
+
+        foreach ($roleNames as $roleName) {
+            $role = $roles->get($roleName);
+
+            if (! $role) {
+                continue;
             }
+
+            if ($permission) {
+                $role->givePermissionTo($permission);
+            }
+
+            $comunicados->roles()->syncWithoutDetaching([$role->id]);
+        }
+
+        if ($administrator = $roles->get('administrator')) {
+            Menu::all()->each(static function (Menu $menu) use ($administrator): void {
+                $menu->roles()->syncWithoutDetaching([$administrator->id]);
+            });
+
+            $administrator->syncPermissions(
+                Permission::query()->where('guard_name', 'web')->get()
+            );
         }
     }
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -139,10 +139,10 @@
                 errors: {},
 
                 get showSubdepartment() {
-                    return this.role && this.role !== 'manager';
+                    return this.role && !['manager', 'administrator'].includes(this.role);
                 },
                 get showTeam() {
-                    return this.role && !['manager', 'director'].includes(this.role);
+                    return this.role && !['manager', 'director', 'administrator'].includes(this.role);
                 },
                 get filteredSubdepartments() {
                     if (!this.area_id) return [];
@@ -178,7 +178,7 @@
                             break;
 
                         case 'role':
-                            const validRoles = ['manager','director','teamLead','teamCoordinator','teamMember'];
+                            const validRoles = this.roles.map(r => r.name);
                             if (!this.role) this.errors.role = 'Debe seleccionar un rol';
                             else if (!validRoles.includes(this.role)) {
                                 this.errors.role = 'Rol inválido';


### PR DESCRIPTION
## Summary
- centralize the registerable role list so validation, seeders, and menu logic reuse the same source of truth
- harden the role and menu seeders to work idempotently against the web guard, remove duplicate records, and keep administrator permissions in sync
- filter the registration view to only show the curated set of roles in the expected order

## Testing
- `composer install` *(fails: requires a GitHub token to download some dependencies in this environment)*
- `php artisan test` *(fails: vendor/autoload.php missing because dependencies could not be installed without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d18a4b2e5883279b91551727bfc26b