### PR TITLE
Align profile form with registration fields

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -17,25 +17,54 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
      */
     public function update(User $user, array $input): void
     {
-        Validator::make($input, [
+        $validated = Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
+            'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id), Rule::in([$user->email])],
             'photo' => ['nullable', 'mimes:jpg,jpeg,png', 'max:1024'],
+            'position' => ['required', 'string', 'max:100'],
+            'role' => ['required', Rule::in([
+                'administrator',
+                'manager',
+                'director',
+                'teamLead',
+                'teamCoordinator',
+                'teamMember',
+            ])],
+            'area_id' => ['required', 'exists:areas,id'],
+            'subdepartment_id' => [
+                Rule::requiredIf(fn () => ! in_array($input['role'] ?? null, ['manager', 'administrator'], true)),
+                'nullable',
+                'exists:subdepartments,id',
+            ],
+            'team_id' => [
+                Rule::requiredIf(fn () => ! in_array($input['role'] ?? null, ['manager', 'director', 'administrator'], true)),
+                'nullable',
+                'exists:teams,id',
+            ],
         ])->validateWithBag('updateProfileInformation');
 
-        if (isset($input['photo'])) {
-            $user->updateProfilePhoto($input['photo']);
+        if (isset($validated['photo'])) {
+            $user->updateProfilePhoto($validated['photo']);
         }
 
-        if ($input['email'] !== $user->email &&
+        if ($validated['email'] !== $user->email &&
             $user instanceof MustVerifyEmail) {
-            $this->updateVerifiedUser($user, $input);
-        } else {
-            $user->forceFill([
-                'name' => $input['name'],
-                'email' => $input['email'],
-            ])->save();
+            $this->updateVerifiedUser($user, $validated);
         }
+
+        $shouldResetSubdepartment = in_array($validated['role'], ['manager', 'administrator'], true);
+        $shouldResetTeam = in_array($validated['role'], ['manager', 'director', 'administrator'], true);
+
+        $user->forceFill([
+            'name' => $validated['name'],
+            'email' => $user->email,
+            'position' => $validated['position'],
+            'area_id' => $validated['area_id'],
+            'subdepartment_id' => $shouldResetSubdepartment ? null : ($validated['subdepartment_id'] ?? null),
+            'team_id' => $shouldResetTeam ? null : ($validated['team_id'] ?? null),
+        ])->save();
+
+        $user->syncRoles([$validated['role']]);
     }
 
     /**

--- a/app/Livewire/Profile/UpdateProfileInformationForm.php
+++ b/app/Livewire/Profile/UpdateProfileInformationForm.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Livewire\Profile;
+
+use App\Models\Area;
+use App\Models\Subdepartment;
+use App\Models\Team;
+use Illuminate\Support\Arr;
+use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm as BaseUpdateProfileInformationForm;
+use Spatie\Permission\Models\Role;
+
+class UpdateProfileInformationForm extends BaseUpdateProfileInformationForm
+{
+    /**
+     * Available role options for the profile form.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $availableRoles = [];
+
+    /**
+     * Available area options for the profile form.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $availableAreas = [];
+
+    /**
+     * Available subdepartment options for the profile form.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $availableSubdepartments = [];
+
+    /**
+     * Available team options for the profile form.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $availableTeams = [];
+
+    /**
+     * Prepare the component state.
+     */
+    public function mount(): void
+    {
+        parent::mount();
+
+        $user = $this->user;
+
+        $this->availableRoles = Role::query()
+            ->select('id', 'name')
+            ->orderBy('name')
+            ->get()
+            ->map(fn ($role) => ['id' => $role->id, 'name' => $role->name])
+            ->all();
+
+        $this->availableAreas = Area::query()
+            ->select('id', 'name')
+            ->orderBy('name')
+            ->get()
+            ->map(fn ($area) => ['id' => $area->id, 'name' => $area->name])
+            ->all();
+
+        $this->availableSubdepartments = Subdepartment::query()
+            ->select('id', 'name', 'area_id')
+            ->orderBy('name')
+            ->get()
+            ->map(fn ($subdepartment) => [
+                'id' => $subdepartment->id,
+                'name' => $subdepartment->name,
+                'area_id' => $subdepartment->area_id,
+            ])
+            ->all();
+
+        $this->availableTeams = Team::query()
+            ->select('id', 'name', 'subdepartment_id')
+            ->orderBy('name')
+            ->get()
+            ->map(fn ($team) => [
+                'id' => $team->id,
+                'name' => $team->name,
+                'subdepartment_id' => $team->subdepartment_id,
+            ])
+            ->all();
+
+        $this->state['role'] = $user->getRoleNames()->first();
+        $this->state['position'] = Arr::get($this->state, 'position', $user->position);
+        $this->state['area_id'] = Arr::get($this->state, 'area_id', $user->area_id);
+        $this->state['subdepartment_id'] = Arr::get($this->state, 'subdepartment_id', $user->subdepartment_id);
+        $this->state['team_id'] = Arr::get($this->state, 'team_id', $user->team_id);
+    }
+
+    /**
+     * Reset dependent fields when the selected area changes.
+     */
+    public function updatedStateAreaId(mixed $_): void
+    {
+        $this->state['subdepartment_id'] = null;
+        $this->state['team_id'] = null;
+    }
+
+    /**
+     * Reset the team when the selected subdepartment changes.
+     */
+    public function updatedStateSubdepartmentId(mixed $_): void
+    {
+        $this->state['team_id'] = null;
+    }
+
+    /**
+     * Ensure dependent selections stay consistent with the chosen role.
+     */
+    public function updatedStateRole(mixed $value): void
+    {
+        if (in_array($value, ['manager', 'administrator'], true)) {
+            $this->state['subdepartment_id'] = null;
+            $this->state['team_id'] = null;
+        } elseif ($value === 'director') {
+            $this->state['team_id'] = null;
+        }
+    }
+}

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -6,10 +6,12 @@ use App\Actions\Jetstream\DeleteUser;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
 use Illuminate\Support\Facades\View;
+use Livewire\Livewire;
 use Spatie\Permission\Models\Role;
 use App\Models\Area;
 use App\Models\Subdepartment;
 use App\Models\Team;
+use App\Livewire\Profile\UpdateProfileInformationForm as ProfileUpdateProfileInformationForm;
 
 
 class JetstreamServiceProvider extends ServiceProvider
@@ -30,6 +32,8 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configurePermissions();
 
         Jetstream::deleteUsersUsing(DeleteUser::class);
+
+        Livewire::component('profile.update-profile-information-form', ProfileUpdateProfileInformationForm::class);
 
         View::composer('auth.register', function ($view) {
             $view->with('roles', Role::all());

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -8,6 +8,21 @@
     </x-slot>
 
     <x-slot name="form">
+        @php
+            $selectedRole = $state['role'] ?? null;
+            $selectedAreaId = $state['area_id'] ?? null;
+            $selectedSubdepartmentId = $state['subdepartment_id'] ?? null;
+
+            $availableSubdepartments = collect($availableSubdepartments ?? []);
+            $availableTeams = collect($availableTeams ?? []);
+
+            $showSubdepartment = $selectedRole && ! in_array($selectedRole, ['manager', 'administrator']);
+            $showTeam = $selectedRole && ! in_array($selectedRole, ['manager', 'director', 'administrator']);
+
+            $filteredSubdepartments = $availableSubdepartments->where('area_id', $selectedAreaId);
+            $filteredTeams = $availableTeams->where('subdepartment_id', $selectedSubdepartmentId);
+        @endphp
+
         <!-- Profile Photo -->
         @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
             <div x-data="{photoName: null, photoPreview: null}" class="col-span-6 sm:col-span-4">
@@ -53,16 +68,16 @@
         @endif
 
         <!-- Name -->
-        <div class="col-span-6 sm:col-span-4">
+        <div class="col-span-6 sm:col-span-3">
             <x-label for="name" value="{{ __('Name') }}" />
             <x-input id="name" type="text" class="mt-1 block w-full" wire:model="state.name" required autocomplete="name" />
             <x-input-error for="name" class="mt-2" />
         </div>
 
         <!-- Email -->
-        <div class="col-span-6 sm:col-span-4">
+        <div class="col-span-6 sm:col-span-3">
             <x-label for="email" value="{{ __('Email') }}" />
-            <x-input id="email" type="email" class="mt-1 block w-full" wire:model="state.email" required autocomplete="username" />
+            <x-input id="email" type="email" class="mt-1 block w-full" wire:model="state.email" autocomplete="username" disabled />
             <x-input-error for="email" class="mt-2" />
 
             @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::emailVerification()) && ! $this->user->hasVerifiedEmail())
@@ -81,6 +96,65 @@
                 @endif
             @endif
         </div>
+
+        <!-- Position -->
+        <div class="col-span-6 sm:col-span-3">
+            <x-label for="position" value="{{ __('Cargo') }}" />
+            <x-input id="position" type="text" class="mt-1 block w-full" wire:model="state.position" autocomplete="organization-title" />
+            <x-input-error for="position" class="mt-2" />
+        </div>
+
+        <!-- Role -->
+        <div class="col-span-6 sm:col-span-3">
+            <x-label for="role" value="{{ __('Role') }}" />
+            <select id="role" wire:model.live="state.role" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+                <option value="" disabled>-- Selecciona un rol --</option>
+                @foreach ($availableRoles ?? [] as $role)
+                    <option value="{{ $role['name'] }}">{{ $role['name'] }}</option>
+                @endforeach
+            </select>
+            <x-input-error for="role" class="mt-2" />
+        </div>
+
+        <!-- Area -->
+        <div class="col-span-6 sm:col-span-3">
+            <x-label for="area_id" value="{{ __('Área') }}" />
+            <select id="area_id" wire:model.live="state.area_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+                <option value="" disabled>-- Selecciona un área --</option>
+                @foreach ($availableAreas ?? [] as $area)
+                    <option value="{{ $area['id'] }}">{{ $area['name'] }}</option>
+                @endforeach
+            </select>
+            <x-input-error for="area_id" class="mt-2" />
+        </div>
+
+        <!-- Subdepartment -->
+        @if ($showSubdepartment)
+            <div class="col-span-6 sm:col-span-3">
+                <x-label for="subdepartment_id" value="{{ __('Subdepartamento') }}" />
+                <select id="subdepartment_id" wire:model.live="state.subdepartment_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+                    <option value="" disabled>-- Selecciona un subdepartamento --</option>
+                    @foreach ($filteredSubdepartments as $subdepartment)
+                        <option value="{{ $subdepartment['id'] }}">{{ $subdepartment['name'] }}</option>
+                    @endforeach
+                </select>
+                <x-input-error for="subdepartment_id" class="mt-2" />
+            </div>
+        @endif
+
+        <!-- Team -->
+        @if ($showTeam)
+            <div class="col-span-6 sm:col-span-3">
+                <x-label for="team_id" value="{{ __('Equipo') }}" />
+                <select id="team_id" wire:model.live="state.team_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300">
+                    <option value="" disabled>-- Selecciona un equipo --</option>
+                    @foreach ($filteredTeams as $team)
+                        <option value="{{ $team['id'] }}">{{ $team['name'] }}</option>
+                    @endforeach
+                </select>
+                <x-input-error for="team_id" class="mt-2" />
+            </div>
+        @endif
     </x-slot>
 
     <x-slot name="actions">

--- a/tests/Feature/ProfileInformationTest.php
+++ b/tests/Feature/ProfileInformationTest.php
@@ -2,10 +2,14 @@
 
 namespace Tests\Feature;
 
+use App\Livewire\Profile\UpdateProfileInformationForm;
+use App\Models\Area;
+use App\Models\Subdepartment;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Laravel\Jetstream\Http\Livewire\UpdateProfileInformationForm;
 use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class ProfileInformationTest extends TestCase
@@ -14,23 +18,128 @@ class ProfileInformationTest extends TestCase
 
     public function test_current_profile_information_is_available(): void
     {
-        $this->actingAs($user = User::factory()->create());
+        $area = Area::create(['name' => 'Tecnología']);
+        $subdepartment = Subdepartment::create([
+            'name' => 'Plataforma',
+            'area_id' => $area->id,
+        ]);
+        $team = Team::create([
+            'name' => 'Equipo Alfa',
+            'subdepartment_id' => $subdepartment->id,
+        ]);
+        $role = Role::create(['name' => 'teamMember']);
+
+        $user = User::factory()->create([
+            'position' => 'Analista',
+            'area_id' => $area->id,
+            'subdepartment_id' => $subdepartment->id,
+            'team_id' => $team->id,
+        ]);
+        $user->assignRole($role);
+
+        $this->actingAs($user);
 
         $component = Livewire::test(UpdateProfileInformationForm::class);
 
         $this->assertEquals($user->name, $component->state['name']);
         $this->assertEquals($user->email, $component->state['email']);
+        $this->assertEquals('Analista', $component->state['position']);
+        $this->assertEquals($role->name, $component->state['role']);
+        $this->assertEquals($area->id, $component->state['area_id']);
+        $this->assertEquals($subdepartment->id, $component->state['subdepartment_id']);
+        $this->assertEquals($team->id, $component->state['team_id']);
     }
 
     public function test_profile_information_can_be_updated(): void
     {
-        $this->actingAs($user = User::factory()->create());
+        $initialArea = Area::create(['name' => 'Operaciones']);
+        $initialSubdepartment = Subdepartment::create([
+            'name' => 'Logística',
+            'area_id' => $initialArea->id,
+        ]);
+        $initialTeam = Team::create([
+            'name' => 'Equipo Base',
+            'subdepartment_id' => $initialSubdepartment->id,
+        ]);
+
+        $targetArea = Area::create(['name' => 'Innovación']);
+        $targetSubdepartment = Subdepartment::create([
+            'name' => 'Investigación',
+            'area_id' => $targetArea->id,
+        ]);
+        $targetTeam = Team::create([
+            'name' => 'Equipo Beta',
+            'subdepartment_id' => $targetSubdepartment->id,
+        ]);
+
+        $memberRole = Role::create(['name' => 'teamMember']);
+        $leadRole = Role::create(['name' => 'teamLead']);
+
+        $user = User::factory()->create([
+            'position' => 'Analista',
+            'area_id' => $initialArea->id,
+            'subdepartment_id' => $initialSubdepartment->id,
+            'team_id' => $initialTeam->id,
+        ]);
+        $user->assignRole($memberRole);
+
+        $this->actingAs($user);
+
+        $originalEmail = $user->email;
 
         Livewire::test(UpdateProfileInformationForm::class)
-            ->set('state', ['name' => 'Test Name', 'email' => 'test@example.com'])
-            ->call('updateProfileInformation');
+            ->set('state.name', 'Nuevo Nombre')
+            ->set('state.email', $originalEmail)
+            ->set('state.position', 'Líder Técnico')
+            ->set('state.role', $leadRole->name)
+            ->set('state.area_id', $targetArea->id)
+            ->set('state.subdepartment_id', $targetSubdepartment->id)
+            ->set('state.team_id', $targetTeam->id)
+            ->call('updateProfileInformation')
+            ->assertHasNoErrors();
 
-        $this->assertEquals('Test Name', $user->fresh()->name);
-        $this->assertEquals('test@example.com', $user->fresh()->email);
+        $user->refresh();
+
+        $this->assertEquals('Nuevo Nombre', $user->name);
+        $this->assertEquals('Líder Técnico', $user->position);
+        $this->assertEquals($targetArea->id, $user->area_id);
+        $this->assertEquals($targetSubdepartment->id, $user->subdepartment_id);
+        $this->assertEquals($targetTeam->id, $user->team_id);
+        $this->assertEquals($originalEmail, $user->email);
+        $this->assertTrue($user->hasRole($leadRole->name));
+        $this->assertFalse($user->hasRole($memberRole->name));
+    }
+
+    public function test_email_cannot_be_updated_from_profile(): void
+    {
+        $area = Area::create(['name' => 'Administración']);
+        $subdepartment = Subdepartment::create([
+            'name' => 'Finanzas',
+            'area_id' => $area->id,
+        ]);
+        $team = Team::create([
+            'name' => 'Equipo Gamma',
+            'subdepartment_id' => $subdepartment->id,
+        ]);
+        $role = Role::create(['name' => 'teamCoordinator']);
+
+        $user = User::factory()->create([
+            'position' => 'Coordinador',
+            'area_id' => $area->id,
+            'subdepartment_id' => $subdepartment->id,
+            'team_id' => $team->id,
+        ]);
+        $user->assignRole($role);
+
+        $this->actingAs($user);
+
+        $originalEmail = $user->email;
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state.email', 'nuevo@segurosbolivar.com')
+            ->call('updateProfileInformation')
+            ->assertHasErrors(['email' => 'in']);
+
+        $this->assertEquals($originalEmail, $user->fresh()->email);
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated Livewire profile form component that exposes roles, areas, subdepartments and teams
- extend Fortify's profile updater to persist the new fields, sync roles and block email changes
- refresh the profile blade to show the additional selectors and add tests that cover the new behaviour

## Testing
- php artisan test *(fails: vendor/autoload.php missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1952dc1e48327b9e11df76796bb6b