### PR TITLE
Add Livewire modal for new collection notice UI

### DIFF
--- a/app/Http/Livewire/Recaudo/Comunicados/CreateRunModal.php
+++ b/app/Http/Livewire/Recaudo/Comunicados/CreateRunModal.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Livewire\Recaudo\Comunicados;
+
+use App\Models\CollectionNoticeType;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+
+class CreateRunModal extends Component
+{
+    use WithFileUploads;
+
+    public bool $open = false;
+
+    public ?int $typeId = null;
+
+    /**
+     * @var array<int, array{id:int, name:string}>
+     */
+    public array $types = [];
+
+    /**
+     * @var array<int, array{id:int, name:string, code:string}>
+     */
+    public array $dataSources = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $files = [];
+
+    /**
+     * @var array<int, string>
+     */
+    protected $listeners = [
+        'openCreateRunModal' => 'handleOpenCreateRunModal',
+    ];
+
+    public function mount(): void
+    {
+        $this->types = CollectionNoticeType::query()
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->toArray();
+    }
+
+    public function updatedTypeId(): void
+    {
+        $this->dataSources = CollectionNoticeType::query()
+            ->with(['dataSources' => fn ($query) => $query->orderBy('name')])
+            ->find($this->typeId)
+            ?->dataSources
+            ->map(fn ($dataSource) => $dataSource->only(['id', 'name', 'code']))
+            ->values()
+            ->all() ?? [];
+
+        $this->files = [];
+    }
+
+    public function getIsFormValidProperty(): bool
+    {
+        return filled($this->typeId)
+            && count($this->dataSources) > 0
+            && $this->allFilesSelected();
+    }
+
+    protected function allFilesSelected(): bool
+    {
+        if (empty($this->dataSources)) {
+            return false;
+        }
+
+        foreach ($this->dataSources as $dataSource) {
+            $key = (string) ($dataSource['id'] ?? '');
+
+            if ($key === '' || ! array_key_exists($key, $this->files) || blank($this->files[$key] ?? null)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function handleOpenCreateRunModal(): void
+    {
+        $this->reset(['typeId', 'dataSources', 'files']);
+        $this->open = true;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.recaudo.comunicados.create-run-modal');
+    }
+}

--- a/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
+++ b/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Livewire\Recaudo\Comunicados;
+namespace App\Livewire\Recaudo\Comunicados;
 
 use App\Models\CollectionNoticeType;
 use Illuminate\Contracts\View\View;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
     "packages": {
         "": {
             "dependencies": {
-                "@alpinejs/collapse": "^3.15.0",
                 "alpinejs": "^3.15.0"
             },
             "devDependencies": {
+                "@alpinejs/collapse": "^3.15.0",
+                "@alpinejs/focus": "^3.15.0",
                 "@tailwindcss/aspect-ratio": "^0.4.2",
                 "@tailwindcss/forms": "^0.5.10",
                 "@tailwindcss/typography": "^0.5.18",
@@ -39,7 +40,19 @@
             "version": "3.15.0",
             "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.0.tgz",
             "integrity": "sha512-RREZVE67/2E7rDZIxw3B5BGAFBm1x/16+3jeyjj+Fky4wPBqnhGCQZujkiggrOmdU6mcZPixYxkKFlhKfQMAXw==",
+            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@alpinejs/focus": {
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.0.tgz",
+            "integrity": "sha512-Cm9vop09oNFw7T9SEBcfijrTdSN1aBNHK3cN4mB52eKvi9z5pa+xcyN+6S3FmZ44MR/u81JXa6hi5CjX1iy6dA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "focus-trap": "^6.9.4",
+                "tabbable": "^5.3.3"
+            }
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.10",
@@ -2015,6 +2028,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/focus-trap": {
+            "version": "6.9.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+            "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tabbable": "^5.3.3"
+            }
+        },
         "node_modules/follow-redirects": {
             "version": "1.15.11",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -3499,6 +3522,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/tabbable": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tailwindcss": {
             "version": "3.4.17",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
         "dev": "vite"
     },
     "devDependencies": {
+        "@alpinejs/collapse": "^3.15.0",
+        "@alpinejs/focus": "^3.15.0",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.18",
@@ -20,7 +22,6 @@
         "vite": "^7.0.4"
     },
     "dependencies": {
-        "@alpinejs/collapse": "^3.15.0",
         "alpinejs": "^3.15.0"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,16 +1,10 @@
 import './bootstrap';
 import '../css/app.css';
 
-import Alpine from 'alpinejs';
 import collapse from '@alpinejs/collapse';
-import './plugins/trap';
+import focus from '@alpinejs/focus';
 
-Alpine.plugin(collapse);
-
-window.Alpine = Alpine;
-
-window.deferLoadingAlpine = (callback) => {
-    document.addEventListener('livewire:init', callback, { once: true });
-};
-
-Alpine.start();
+document.addEventListener('alpine:init', () => {
+    window.Alpine.plugin(collapse);
+    window.Alpine.plugin(focus);
+});

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,10 +1,17 @@
 import './bootstrap';
 import '../css/app.css';
-import Alpine from 'alpinejs';
-import collapse from '@alpinejs/collapse'; // Importa el plugin
 
-window.Alpine = Alpine;
+import collapse from '@alpinejs/collapse';
+import './plugins/trap';
 
-Alpine.plugin(collapse); // Registra el plugin
+window.deferLoadingAlpine = (callback) => {
+    document.addEventListener('livewire:init', callback, { once: true });
+};
 
-Alpine.start();
+document.addEventListener('alpine:init', () => {
+    if (! window.Alpine) {
+        return;
+    }
+
+    window.Alpine.plugin(collapse);
+});

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,17 +1,16 @@
 import './bootstrap';
 import '../css/app.css';
 
+import Alpine from 'alpinejs';
 import collapse from '@alpinejs/collapse';
 import './plugins/trap';
+
+Alpine.plugin(collapse);
+
+window.Alpine = Alpine;
 
 window.deferLoadingAlpine = (callback) => {
     document.addEventListener('livewire:init', callback, { once: true });
 };
 
-document.addEventListener('alpine:init', () => {
-    if (! window.Alpine) {
-        return;
-    }
-
-    window.Alpine.plugin(collapse);
-});
+Alpine.start();

--- a/resources/js/plugins/trap.js
+++ b/resources/js/plugins/trap.js
@@ -1,0 +1,170 @@
+const focusableSelectors = [
+    'a[href]:not([tabindex="-1"])',
+    'area[href]:not([tabindex="-1"])',
+    'input:not([disabled]):not([tabindex="-1"])',
+    'select:not([disabled]):not([tabindex="-1"])',
+    'textarea:not([disabled]):not([tabindex="-1"])',
+    'button:not([disabled]):not([tabindex="-1"])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const collectFocusable = (root) => {
+    return Array.from(root.querySelectorAll(focusableSelectors)).filter(
+        (element) => ! element.hasAttribute('disabled') && ! element.getAttribute('aria-hidden')
+    );
+};
+
+document.addEventListener('alpine:init', () => {
+    const Alpine = window.Alpine;
+
+    if (! Alpine) {
+        return;
+    }
+
+    Alpine.directive('trap', (el, { expression, modifiers }, { cleanup, effect, evaluateLater }) => {
+        const evaluate = evaluateLater(expression);
+
+        let active = false;
+        let previousFocused = null;
+        let releaseInert = () => {};
+        let releaseNoScroll = () => {};
+
+        const enforceFocus = (event) => {
+            if (! active) {
+                return;
+            }
+
+            if (el.contains(event.target)) {
+                return;
+            }
+
+            const focusable = collectFocusable(el);
+
+            if (focusable.length === 0) {
+                return;
+            }
+
+            focusable[0].focus({ preventScroll: true });
+        };
+
+        const handleKeydown = (event) => {
+            if (! active || event.key !== 'Tab') {
+                return;
+            }
+
+            const focusable = collectFocusable(el);
+
+            if (focusable.length === 0) {
+                event.preventDefault();
+                return;
+            }
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+            const current = document.activeElement;
+
+            if (event.shiftKey) {
+                if (current === first || ! el.contains(current)) {
+                    event.preventDefault();
+                    last.focus({ preventScroll: true });
+                }
+
+                return;
+            }
+
+            if (current === last) {
+                event.preventDefault();
+                first.focus({ preventScroll: true });
+            }
+        };
+
+        const applyInert = () => {
+            if (! modifiers.includes('inert')) {
+                return () => {};
+            }
+
+            const siblings = Array.from(document.body.children).filter((child) => ! child.contains(el));
+            siblings.forEach((sibling) => sibling.setAttribute('inert', ''));
+
+            return () => {
+                siblings.forEach((sibling) => sibling.removeAttribute('inert'));
+            };
+        };
+
+        const applyNoScroll = () => {
+            if (! modifiers.includes('noscroll')) {
+                return () => {};
+            }
+
+            const originalOverflow = document.documentElement.style.overflow;
+            const originalPaddingRight = document.documentElement.style.paddingRight;
+
+            const scrollBarWidth = window.innerWidth - document.documentElement.clientWidth;
+
+            document.documentElement.style.overflow = 'hidden';
+
+            if (scrollBarWidth > 0) {
+                document.documentElement.style.paddingRight = `${scrollBarWidth}px`;
+            }
+
+            return () => {
+                document.documentElement.style.overflow = originalOverflow;
+                document.documentElement.style.paddingRight = originalPaddingRight;
+            };
+        };
+
+        const activate = () => {
+            if (active) {
+                return;
+            }
+
+            active = true;
+            previousFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+            releaseInert = applyInert();
+            releaseNoScroll = applyNoScroll();
+
+            document.addEventListener('focusin', enforceFocus, true);
+            el.addEventListener('keydown', handleKeydown, true);
+
+            const focusable = collectFocusable(el);
+            if (focusable.length > 0) {
+                focusable[0].focus({ preventScroll: true });
+            } else {
+                el.focus({ preventScroll: true });
+            }
+        };
+
+        const deactivate = () => {
+            if (! active) {
+                return;
+            }
+
+            active = false;
+
+            document.removeEventListener('focusin', enforceFocus, true);
+            el.removeEventListener('keydown', handleKeydown, true);
+
+            releaseInert();
+            releaseNoScroll();
+
+            if (previousFocused && previousFocused.focus) {
+                previousFocused.focus({ preventScroll: true });
+            }
+        };
+
+        effect(() => {
+            evaluate((value) => {
+                if (Boolean(value)) {
+                    activate();
+                } else {
+                    deactivate();
+                }
+            });
+        });
+
+        cleanup(() => {
+            deactivate();
+        });
+    });
+});

--- a/resources/views/components/dialog-modal.blade.php
+++ b/resources/views/components/dialog-modal.blade.php
@@ -1,17 +1,46 @@
-@props(['id' => null, 'maxWidth' => null])
+@props(['id' => null, 'maxWidth' => '3xl'])
 
-<x-modal :id="$id" :maxWidth="$maxWidth" {{ $attributes }}>
-    <div class="px-6 py-4">
-        <div class="text-lg font-medium text-gray-900 dark:text-gray-100">
+@php
+    $map = [
+        'sm' => 'sm:max-w-sm',
+        'md' => 'sm:max-w-md',
+        'lg' => 'sm:max-w-lg',
+        'xl' => 'sm:max-w-xl',
+        '2xl' => 'sm:max-w-2xl',
+        '3xl' => 'sm:max-w-3xl',
+    ];
+    $maxWidthClass = $map[$maxWidth] ?? $map['3xl'];
+@endphp
+
+<div
+    x-data="{ show: @entangle($attributes->wire('model')).live }"
+    x-show="show"
+    x-on:close.stop="show = false"
+    x-on:keydown.escape.window="show = false"
+    id="{{ $id ?? Str::random(32) }}"
+    class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
+    style="display: none;"
+>
+    <!-- Overlay -->
+    <div x-show="show" x-transition.opacity class="fixed inset-0 transform transition-all" x-on:click="show = false">
+        <div class="absolute inset-0 bg-black/50"></div>
+    </div>
+
+    <!-- Panel -->
+    <div x-show="show"
+         x-transition
+         x-trap.inert.noscroll="show"
+         class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidthClass }} sm:mx-auto">
+        <div class="px-6 py-4">
             {{ $title }}
         </div>
 
-        <div class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+        <div class="px-6 py-4">
             {{ $content }}
         </div>
-    </div>
 
-    <div class="flex flex-row justify-end px-6 py-4 bg-gray-100 dark:bg-gray-800 text-end">
-        {{ $footer }}
+        <div class="px-6 py-4 bg-gray-100 dark:bg-gray-900/50">
+            {{ $footer }}
+        </div>
     </div>
-</x-modal>
+</div>

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,46 +1,247 @@
-@props(['id', 'maxWidth'])
+@props(['id' => null, 'maxWidth' => '2xl'])
 
 @php
-$id = $id ?? md5($attributes->wire('model'));
+    $id = $id ?? md5($attributes->wire('model'));
 
-$availableMaxWidths = [
-    'sm' => 'sm:max-w-sm',
-    'md' => 'sm:max-w-md',
-    'lg' => 'sm:max-w-lg',
-    'xl' => 'sm:max-w-xl',
-    '2xl' => 'sm:max-w-2xl',
-    '3xl' => 'sm:max-w-3xl',
-];
+    $availableMaxWidths = [
+        'sm' => 'sm:max-w-sm',
+        'md' => 'sm:max-w-md',
+        'lg' => 'sm:max-w-lg',
+        'xl' => 'sm:max-w-xl',
+        '2xl' => 'sm:max-w-2xl',
+        '3xl' => 'sm:max-w-3xl',
+    ];
 
-$maxWidth = $availableMaxWidths[$maxWidth ?? '2xl'] ?? $availableMaxWidths['2xl'];
+    $maxWidth = $availableMaxWidths[$maxWidth ?? '2xl'] ?? $availableMaxWidths['2xl'];
+
+    $wireModelProperty = null;
+
+    foreach ($attributes->getAttributes() as $attributeKey => $attributeValue) {
+        if (str_starts_with($attributeKey, 'wire:model')) {
+            $wireModelProperty = $attributeValue;
+
+            break;
+        }
+    }
 @endphp
 
 <div
-    x-data="{ show: @entangle($attributes->wire('model')) }"
-    x-on:close.stop="show = false"
-    x-on:keydown.escape.window="show = false"
+    x-data='modalComponent({ property: @js($wireModelProperty) })'
+    x-init="init()"
+    x-on:close.stop="close()"
+    x-on:keydown.escape.window="close()"
     x-show="show"
+    x-cloak
     id="{{ $id }}"
     class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
     style="display: none;"
 >
-    <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
-                    x-transition:enter-start="opacity-0"
-                    x-transition:enter-end="opacity-100"
-                    x-transition:leave="ease-in duration-200"
-                    x-transition:leave-start="opacity-100"
-                    x-transition:leave-end="opacity-0">
+    <div
+        x-show="show"
+        class="fixed inset-0 transform transition-all"
+        x-on:click="close()"
+        x-transition:enter="ease-out duration-300"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="ease-in duration-200"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+    >
         <div class="absolute inset-0 bg-gray-500 dark:bg-gray-900 opacity-75"></div>
     </div>
 
-    <div x-show="show" class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
-                    x-trap.inert.noscroll="show"
-                    x-transition:enter="ease-out duration-300"
-                    x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                    x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
-                    x-transition:leave="ease-in duration-200"
-                    x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
-                    x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+    <div
+        x-show="show"
+        class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+        x-trap.inert.noscroll="show"
+        x-transition:enter="ease-out duration-300"
+        x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave="ease-in duration-200"
+        x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+        x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+    >
         {{ $slot }}
     </div>
 </div>
+
+@once
+    <script>
+        document.addEventListener('alpine:init', () => {
+            const Alpine = window.Alpine;
+
+            if (! Alpine) {
+                return;
+            }
+
+            const readProperty = (component, property) => {
+                if (! component || ! property) {
+                    return undefined;
+                }
+
+                if (typeof component.get === 'function') {
+                    return component.get(property);
+                }
+
+                if (component.$wire && typeof component.$wire.get === 'function') {
+                    return component.$wire.get(property);
+                }
+
+                return undefined;
+            };
+
+            const setProperty = (component, property, value) => {
+                if (! component || ! property) {
+                    return;
+                }
+
+                if (typeof component.set === 'function') {
+                    component.set(property, value);
+
+                    return;
+                }
+
+                if (component.$wire && typeof component.$wire.set === 'function') {
+                    component.$wire.set(property, value);
+                }
+            };
+
+            const watchProperty = (component, property, callback) => {
+                if (! component || ! property || typeof callback !== 'function') {
+                    return null;
+                }
+
+                if (typeof component.watch === 'function') {
+                    return component.watch(property, callback);
+                }
+
+                if (window.Livewire && typeof window.Livewire.hook === 'function') {
+                    const release = window.Livewire.hook('message.processed', (message, instance) => {
+                        if (instance.id !== component.id) {
+                            return;
+                        }
+
+                        callback(readProperty(instance, property));
+                    });
+
+                    return () => {
+                        if (typeof release === 'function') {
+                            release();
+                        }
+                    };
+                }
+
+                return null;
+            };
+
+            const runMicrotask = (callback) => {
+                if (typeof queueMicrotask === 'function') {
+                    queueMicrotask(callback);
+
+                    return;
+                }
+
+                Promise.resolve().then(callback);
+            };
+
+            Alpine.data('modalComponent', (config = {}) => ({
+                show: false,
+                property: config.property ?? null,
+                livewireComponentId: null,
+                livewire: null,
+                syncingFromLivewire: false,
+                removeWatcher: null,
+
+                init() {
+                    if (! this.property) {
+                        return;
+                    }
+
+                    const parent = this.$root.closest('[wire\\:id]');
+
+                    if (! parent) {
+                        return;
+                    }
+
+                    this.livewireComponentId = parent.getAttribute('wire:id');
+
+                    if (! this.livewireComponentId) {
+                        return;
+                    }
+
+                    const attemptAttach = () => {
+                        const component = window.Livewire && typeof window.Livewire.find === 'function'
+                            ? window.Livewire.find(this.livewireComponentId)
+                            : null;
+
+                        if (! component) {
+                            requestAnimationFrame(attemptAttach);
+
+                            return;
+                        }
+
+                        this.attachTo(component);
+                    };
+
+                    attemptAttach();
+
+                    this.$watch('show', (value) => {
+                        if (this.syncingFromLivewire) {
+                            return;
+                        }
+
+                        this.updateLivewire(value);
+                    });
+
+                    this.$root.addEventListener('alpine:destroy', () => {
+                        if (typeof this.removeWatcher === 'function') {
+                            this.removeWatcher();
+                            this.removeWatcher = null;
+                        }
+                    });
+                },
+
+                attachTo(component) {
+                    this.livewire = component;
+
+                    this.syncingFromLivewire = true;
+                    this.show = Boolean(readProperty(component, this.property));
+                    runMicrotask(() => {
+                        this.syncingFromLivewire = false;
+                    });
+
+                    const release = watchProperty(component, this.property, (value) => {
+                        this.syncingFromLivewire = true;
+                        this.show = Boolean(value);
+                        runMicrotask(() => {
+                            this.syncingFromLivewire = false;
+                        });
+                    });
+
+                    if (typeof release === 'function') {
+                        this.removeWatcher = release;
+                    }
+                },
+
+                updateLivewire(value) {
+                    if (! this.livewire || ! this.property) {
+                        return;
+                    }
+
+                    const normalized = Boolean(value);
+                    const current = Boolean(readProperty(this.livewire, this.property));
+
+                    if (normalized === current) {
+                        return;
+                    }
+
+                    setProperty(this.livewire, this.property, normalized);
+                },
+
+                close() {
+                    this.show = false;
+                },
+            }));
+        });
+    </script>
+@endonce

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -13,18 +13,116 @@ $availableMaxWidths = [
 ];
 
 $maxWidth = $availableMaxWidths[$maxWidth ?? '2xl'] ?? $availableMaxWidths['2xl'];
+
+$wireModel = $attributes->wire('model');
+$modelProperty = $wireModel ? (string) $wireModel : null;
 @endphp
 
 <div
-    x-data="{ show: @entangle($attributes->wire('model')) }"
-    x-on:close.stop="show = false"
-    x-on:keydown.escape.window="show = false"
+    x-data="{
+        show: false,
+        property: @js($modelProperty),
+        componentId: null,
+        watchRegistered: false,
+        commitHookBound: false,
+        livewireComponent() {
+            if (! this.property) {
+                return null;
+            }
+
+            if (this.componentId && window.Livewire) {
+                return window.Livewire.find(this.componentId);
+            }
+
+            const root = this.$el.closest('[wire\\:id]');
+
+            if (! root || ! window.Livewire) {
+                return null;
+            }
+
+            this.componentId = root.getAttribute('wire:id');
+
+            return this.componentId ? window.Livewire.find(this.componentId) : null;
+        },
+        syncFromLivewire() {
+            const component = this.livewireComponent();
+
+            if (! component || ! this.property) {
+                return;
+            }
+
+            this.show = Boolean(component.get(this.property));
+        },
+        init() {
+            if (! this.property) {
+                return;
+            }
+
+            const bind = () => {
+                const component = this.livewireComponent();
+
+                if (! component) {
+                    requestAnimationFrame(bind);
+                    return;
+                }
+
+                this.syncFromLivewire();
+
+                if (! this.watchRegistered) {
+                    this.$watch('show', (value) => {
+                        const currentComponent = this.livewireComponent();
+
+                        if (! currentComponent || ! this.property) {
+                            return;
+                        }
+
+                        const current = Boolean(currentComponent.get(this.property));
+                        const next = Boolean(value);
+
+                        if (current === next) {
+                            return;
+                        }
+
+                        currentComponent.set(this.property, next);
+                    });
+
+                    this.watchRegistered = true;
+                }
+
+                if (window.Livewire && typeof window.Livewire.hook === 'function' && ! this.commitHookBound) {
+                    window.Livewire.hook('commit', (payload, component) => {
+                        const target = component || (payload && payload.component) || null;
+
+                        if (! target || target.id !== this.componentId) {
+                            return;
+                        }
+
+                        this.syncFromLivewire();
+                    });
+
+                    this.commitHookBound = true;
+                }
+            };
+
+            if (window.Livewire) {
+                bind();
+            } else {
+                document.addEventListener('livewire:init', bind, { once: true });
+            }
+        },
+        close() {
+            this.show = false;
+        },
+    }"
+    x-on:close.stop="close()"
+    x-on:keydown.escape.window="close()"
     x-show="show"
+    x-cloak
     id="{{ $id }}"
     class="jetstream-modal fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50"
     style="display: none;"
 >
-    <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="show = false" x-transition:enter="ease-out duration-300"
+    <div x-show="show" class="fixed inset-0 transform transition-all" x-on:click="close()" x-transition:enter="ease-out duration-300"
                     x-transition:enter-start="opacity-0"
                     x-transition:enter-end="opacity-100"
                     x-transition:leave="ease-in duration-200"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -3,13 +3,16 @@
 @php
 $id = $id ?? md5($attributes->wire('model'));
 
-$maxWidth = [
+$availableMaxWidths = [
     'sm' => 'sm:max-w-sm',
     'md' => 'sm:max-w-md',
     'lg' => 'sm:max-w-lg',
     'xl' => 'sm:max-w-xl',
     '2xl' => 'sm:max-w-2xl',
-][$maxWidth ?? '2xl'];
+    '3xl' => 'sm:max-w-3xl',
+];
+
+$maxWidth = $availableMaxWidths[$maxWidth ?? '2xl'] ?? $availableMaxWidths['2xl'];
 @endphp
 
 <div

--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -5,53 +5,92 @@
         </x-slot>
 
         <x-slot name="content">
-            <div class="space-y-6">
-                <div class="space-y-2">
+            <div class="space-y-8">
+                <div class="space-y-3">
                     <x-label for="collection_notice_type_id" value="{{ __('Tipo de comunicado') }}" />
 
                     <select
                         id="collection_notice_type_id"
                         name="collection_notice_type_id"
                         wire:model.live="typeId"
-                        required
-                        class="block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                        class="block w-full rounded-3xl border border-gray-300 bg-white px-4 py-3 text-sm text-gray-700 shadow-sm transition focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                     >
                         <option value="">{{ __('Selecciona un tipo de comunicado') }}</option>
                         @foreach ($types as $type)
                             <option value="{{ $type['id'] }}">{{ $type['name'] }}</option>
                         @endforeach
                     </select>
+
+                    @error('typeId')
+                        <p class="inline-flex items-center rounded-3xl bg-danger-600 px-3 py-1 text-xs font-semibold text-white">
+                            {{ $message }}
+                        </p>
+                    @enderror
                 </div>
 
                 <div class="space-y-4">
+                    <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                        {{ __('Insumos requeridos') }}
+                    </h3>
+
                     @if (! filled($typeId))
-                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <p class="rounded-3xl bg-gray-100 px-4 py-3 text-sm text-gray-600 dark:bg-gray-900/60 dark:text-gray-300">
                             {{ __('Selecciona un tipo de comunicado para ver los insumos requeridos.') }}
                         </p>
+                    @elseif (empty($dataSources))
+                        <div class="rounded-3xl border border-dashed border-gray-300 px-4 py-4 text-sm text-gray-600 dark:border-gray-600 dark:text-gray-300">
+                            {{ __('El tipo de comunicado seleccionado no tiene insumos configurados actualmente.') }}
+                        </div>
                     @else
-                        @if (empty($dataSources))
-                            <div class="rounded-2xl border border-dashed border-gray-300 px-4 py-3 text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
-                                {{ __('El tipo de comunicado seleccionado no tiene insumos configurados actualmente.') }}
-                            </div>
-                        @else
-                            <div class="space-y-5">
-                                @foreach ($dataSources as $dataSource)
-                                    <div wire:key="data-source-{{ $dataSource['id'] }}" class="space-y-2">
-                                        <x-label for="file-{{ $dataSource['id'] }}" :value="$dataSource['name']" />
+                        <div class="space-y-6">
+                            @foreach ($dataSources as $dataSource)
+                                @php($fileKey = (string) ($dataSource['id'] ?? ''))
+                                @php($selectedFile = $fileKey !== '' ? ($files[$fileKey] ?? null) : null)
 
-                                        <input
-                                            id="file-{{ $dataSource['id'] }}"
-                                            name="files[{{ $dataSource['id'] }}]"
-                                            type="file"
-                                            wire:model.live="files.{{ $dataSource['id'] }}"
-                                            accept=".csv,.xlsx,.xls"
-                                            required
-                                            class="block w-full cursor-pointer rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
-                                        />
+                                <div wire:key="data-source-{{ $dataSource['id'] }}" class="space-y-2">
+                                    <div class="grid items-center gap-4 sm:grid-cols-[minmax(0,1fr)_auto]">
+                                        <div class="space-y-1">
+                                            <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                                {{ $dataSource['name'] }}
+                                            </p>
+                                            <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                {{ __('Código: :code', ['code' => $dataSource['code']]) }}
+                                            </p>
+                                        </div>
+
+                                        <div class="flex flex-col items-start gap-2 sm:items-end">
+                                            <label
+                                                for="file-{{ $dataSource['id'] }}"
+                                                class="inline-flex w-full items-center justify-center gap-2 rounded-3xl border border-primary-300 bg-white px-4 py-2 text-sm font-semibold text-primary-900 shadow-sm transition hover:border-primary-500 hover:bg-primary-200/60 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-gray-600 dark:bg-gray-900 dark:text-primary-200 dark:focus-within:ring-offset-gray-900 sm:w-auto"
+                                            >
+                                                <i class="fa-solid fa-upload"></i>
+                                                <span>{{ __('Seleccionar archivo') }}</span>
+                                                <input
+                                                    id="file-{{ $dataSource['id'] }}"
+                                                    name="files[{{ $dataSource['id'] }}]"
+                                                    type="file"
+                                                    wire:model.live="files.{{ $dataSource['id'] }}"
+                                                    accept=".csv,.xlsx,.xls"
+                                                    class="sr-only"
+                                                />
+                                            </label>
+
+                                            @if ($selectedFile)
+                                                <p class="max-w-full truncate rounded-3xl bg-gray-100 px-3 py-1 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                                                    {{ method_exists($selectedFile, 'getClientOriginalName') ? $selectedFile->getClientOriginalName() : (string) $selectedFile }}
+                                                </p>
+                                            @endif
+                                        </div>
                                     </div>
-                                @endforeach
-                            </div>
-                        @endif
+
+                                    @error('files.' . $dataSource['id'])
+                                        <p class="inline-flex items-center rounded-3xl bg-danger-600 px-3 py-1 text-xs font-semibold text-white">
+                                            {{ $message }}
+                                        </p>
+                                    @enderror
+                                </div>
+                            @endforeach
+                        </div>
                     @endif
                 </div>
             </div>
@@ -59,20 +98,24 @@
 
         <x-slot name="footer">
             <div class="flex w-full justify-end gap-3">
-                <x-secondary-button type="button" wire:click="$set('open', false)">
+                <button
+                    type="button"
+                    wire:click="cancel"
+                    class="inline-flex items-center justify-center gap-2 rounded-3xl bg-danger px-5 py-2 text-button font-semibold text-white transition hover:bg-danger-300 focus:outline-none focus:ring-2 focus:ring-danger-300 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900"
+                >
                     {{ __('Cancelar') }}
-                </x-secondary-button>
+                </button>
 
                 @php($isFormValid = $this->isFormValid)
 
-                <x-button
+                <button
                     type="button"
-                    class="disabled:cursor-not-allowed disabled:opacity-50"
-                    :disabled="! $isFormValid"
-                    :aria-disabled="$isFormValid ? 'false' : 'true'"
+                    wire:click="submit"
+                    @if (! $isFormValid) disabled aria-disabled="true" @else aria-disabled="false" @endif
+                    class="inline-flex items-center justify-center gap-2 rounded-3xl bg-primary-900 px-5 py-2 text-button font-semibold text-primary transition hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:focus:ring-offset-gray-900"
                 >
-                    {{ __('Continuar') }}
-                </x-button>
+                    {{ __('Aceptar') }}
+                </button>
             </div>
         </x-slot>
     </x-dialog-modal>

--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -28,28 +28,30 @@
                         <p class="text-sm text-gray-500 dark:text-gray-400">
                             {{ __('Selecciona un tipo de comunicado para ver los insumos requeridos.') }}
                         </p>
-                    @elseif (empty($dataSources))
-                        <div class="rounded-2xl border border-dashed border-gray-300 px-4 py-3 text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
-                            {{ __('El tipo de comunicado seleccionado no tiene insumos configurados actualmente.') }}
-                        </div>
                     @else
-                        <div class="space-y-5">
-                            @foreach ($dataSources as $dataSource)
-                                <div wire:key="data-source-{{ $dataSource['id'] }}" class="space-y-2">
-                                    <x-label for="file-{{ $dataSource['id'] }}" :value="$dataSource['name']" />
+                        @if (empty($dataSources))
+                            <div class="rounded-2xl border border-dashed border-gray-300 px-4 py-3 text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+                                {{ __('El tipo de comunicado seleccionado no tiene insumos configurados actualmente.') }}
+                            </div>
+                        @else
+                            <div class="space-y-5">
+                                @foreach ($dataSources as $dataSource)
+                                    <div wire:key="data-source-{{ $dataSource['id'] }}" class="space-y-2">
+                                        <x-label for="file-{{ $dataSource['id'] }}" :value="$dataSource['name']" />
 
-                                    <input
-                                        id="file-{{ $dataSource['id'] }}"
-                                        name="files[{{ $dataSource['id'] }}]"
-                                        type="file"
-                                        wire:model.live="files.{{ $dataSource['id'] }}"
-                                        accept=".csv,.xlsx,.xls"
-                                        required
-                                        class="block w-full cursor-pointer rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
-                                    />
-                                </div>
-                            @endforeach
-                        </div>
+                                        <input
+                                            id="file-{{ $dataSource['id'] }}"
+                                            name="files[{{ $dataSource['id'] }}]"
+                                            type="file"
+                                            wire:model.live="files.{{ $dataSource['id'] }}"
+                                            accept=".csv,.xlsx,.xls"
+                                            required
+                                            class="block w-full cursor-pointer rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                                        />
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
                     @endif
                 </div>
             </div>

--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -68,8 +68,8 @@
                 <x-button
                     type="button"
                     class="disabled:cursor-not-allowed disabled:opacity-50"
-                    @disabled(! $isFormValid)
-                    aria-disabled="{{ $isFormValid ? 'false' : 'true' }}"
+                    :disabled="! $isFormValid"
+                    :aria-disabled="$isFormValid ? 'false' : 'true'"
                 >
                     {{ __('Continuar') }}
                 </x-button>

--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -1,0 +1,77 @@
+<div>
+    <x-dialog-modal wire:model.live="open" maxWidth="3xl">
+        <x-slot name="title">
+            {{ __('Nuevo Comunicado') }}
+        </x-slot>
+
+        <x-slot name="content">
+            <div class="space-y-6">
+                <div class="space-y-2">
+                    <x-label for="collection_notice_type_id" value="{{ __('Tipo de comunicado') }}" />
+
+                    <select
+                        id="collection_notice_type_id"
+                        name="collection_notice_type_id"
+                        wire:model.live="typeId"
+                        required
+                        class="block w-full rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                    >
+                        <option value="">{{ __('Selecciona un tipo de comunicado') }}</option>
+                        @foreach ($types as $type)
+                            <option value="{{ $type['id'] }}">{{ $type['name'] }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="space-y-4">
+                    @if (! filled($typeId))
+                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                            {{ __('Selecciona un tipo de comunicado para ver los insumos requeridos.') }}
+                        </p>
+                    @elseif (empty($dataSources))
+                        <div class="rounded-2xl border border-dashed border-gray-300 px-4 py-3 text-sm text-gray-500 dark:border-gray-600 dark:text-gray-400">
+                            {{ __('El tipo de comunicado seleccionado no tiene insumos configurados actualmente.') }}
+                        </div>
+                    @else
+                        <div class="space-y-5">
+                            @foreach ($dataSources as $dataSource)
+                                <div wire:key="data-source-{{ $dataSource['id'] }}" class="space-y-2">
+                                    <x-label for="file-{{ $dataSource['id'] }}" :value="$dataSource['name']" />
+
+                                    <input
+                                        id="file-{{ $dataSource['id'] }}"
+                                        name="files[{{ $dataSource['id'] }}]"
+                                        type="file"
+                                        wire:model.live="files.{{ $dataSource['id'] }}"
+                                        accept=".csv,.xlsx,.xls"
+                                        required
+                                        class="block w-full cursor-pointer rounded-2xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                                    />
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </x-slot>
+
+        <x-slot name="footer">
+            <div class="flex w-full justify-end gap-3">
+                <x-secondary-button type="button" wire:click="$set('open', false)">
+                    {{ __('Cancelar') }}
+                </x-secondary-button>
+
+                @php($isFormValid = $this->isFormValid)
+
+                <x-button
+                    type="button"
+                    class="disabled:cursor-not-allowed disabled:opacity-50"
+                    @disabled(! $isFormValid)
+                    aria-disabled="{{ $isFormValid ? 'false' : 'true' }}"
+                >
+                    {{ __('Continuar') }}
+                </x-button>
+            </div>
+        </x-slot>
+    </x-dialog-modal>
+</div>

--- a/resources/views/recaudo/comunicados/index.blade.php
+++ b/resources/views/recaudo/comunicados/index.blade.php
@@ -7,13 +7,15 @@
                         {{ __('Comunicados cartera') }}
                     </h1>
 
-                    <a
-                        href="#"
+                    <button
+                        type="button"
+                        x-data="{}"
+                        x-on:click.prevent="Livewire.dispatch('openCreateRunModal')"
                         class="col-span-12 desktop:col-span-3 inline-flex w-full items-center justify-center gap-2 rounded-3xl bg-secondary-900 px-5 py-3 text-button font-semibold text-primary transition hover:bg-secondary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900 desktop:w-auto desktop:justify-self-end"
                     >
                         <i class="fa-solid fa-plus"></i>
                         <span>{{ __('Nuevo Comunicado') }}</span>
-                    </a>
+                    </button>
                 </div>
 
                 <div class="mt-8 space-y-6">
@@ -35,4 +37,6 @@
             </div>
         </div>
     </div>
+
+    @livewire('recaudo.comunicados.create-run-modal')
 </x-app-layout>

--- a/resources/views/vendor/jetstream/components/modal.blade.php
+++ b/resources/views/vendor/jetstream/components/modal.blade.php
@@ -1,0 +1,8 @@
+@props(['id' => null, 'maxWidth' => '2xl'])
+
+@include('components.modal', [
+    'id' => $id,
+    'maxWidth' => $maxWidth,
+    'attributes' => $attributes,
+    'slot' => $slot,
+])


### PR DESCRIPTION
## Summary
- add a Livewire component to manage the "Nuevo Comunicado" modal and preload available notice types
- render the modal UI with per-insumo file upload controls and validation state tracking
- hook the index action button to trigger the modal without reloading the page

## Testing
- `php artisan test` *(fails: vendor dependencies missing and Composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3317e6e2883278b0a0c402e9b6317