### PR TITLE
Implement collection notice runs listing

### DIFF
--- a/app/DTOs/Recaudo/Comunicados/CollectionNoticeRunFiltersDto.php
+++ b/app/DTOs/Recaudo/Comunicados/CollectionNoticeRunFiltersDto.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\DTOs\Recaudo\Comunicados;
+
+use Carbon\CarbonImmutable;
+
+final class CollectionNoticeRunFiltersDto
+{
+    public function __construct(
+        public readonly ?int $requestedById,
+        public readonly ?int $collectionNoticeTypeId,
+        public readonly ?CarbonImmutable $dateFrom,
+        public readonly ?CarbonImmutable $dateTo,
+    ) {
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    public static function fromArray(array $filters): self
+    {
+        return new self(
+            isset($filters['requested_by_id']) ? (int) $filters['requested_by_id'] : null,
+            isset($filters['collection_notice_type_id']) ? (int) $filters['collection_notice_type_id'] : null,
+            isset($filters['date_from']) && $filters['date_from'] !== null
+                ? CarbonImmutable::parse($filters['date_from'])->startOfDay()
+                : null,
+            isset($filters['date_to']) && $filters['date_to'] !== null
+                ? CarbonImmutable::parse($filters['date_to'])->endOfDay()
+                : null,
+        );
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function toQuery(): array
+    {
+        $query = [];
+
+        if ($this->requestedById !== null) {
+            $query['requested_by_id'] = $this->requestedById;
+        }
+
+        if ($this->collectionNoticeTypeId !== null) {
+            $query['collection_notice_type_id'] = $this->collectionNoticeTypeId;
+        }
+
+        if ($this->dateFrom !== null) {
+            $query['date_from'] = $this->dateFrom->format('Y-m-d');
+        }
+
+        if ($this->dateTo !== null) {
+            $query['date_to'] = $this->dateTo->format('Y-m-d');
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array<string, int|string|null>
+     */
+    public function toViewData(): array
+    {
+        return [
+            'requested_by_id' => $this->requestedById,
+            'collection_notice_type_id' => $this->collectionNoticeTypeId,
+            'date_from' => $this->dateFrom?->format('Y-m-d'),
+            'date_to' => $this->dateTo?->format('Y-m-d'),
+        ];
+    }
+}

--- a/app/Http/Controllers/CollectionNoticeRunsController.php
+++ b/app/Http/Controllers/CollectionNoticeRunsController.php
@@ -2,9 +2,22 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\UseCases\Recaudo\Comunicados\ListCollectionNoticeRunsUseCase;
+use Illuminate\Contracts\View\View;
 
-class CollectionNoticeRunsController extends Controller
+final class CollectionNoticeRunsController extends Controller
 {
-    //
+    public function __construct(
+        private readonly ListCollectionNoticeRunsUseCase $listCollectionNoticeRuns,
+    ) {
+    }
+
+    public function index(): View
+    {
+        $runs = ($this->listCollectionNoticeRuns)();
+
+        return view('recaudo.comunicados.index', [
+            'runs' => $runs,
+        ]);
+    }
 }

--- a/app/Http/Controllers/CollectionNoticeRunsController.php
+++ b/app/Http/Controllers/CollectionNoticeRunsController.php
@@ -2,8 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\DTOs\Recaudo\Comunicados\CollectionNoticeRunFiltersDto;
+use App\Http\Requests\Recaudo\CollectionNoticeRunIndexRequest;
+use App\Models\CollectionNoticeType;
+use App\Models\User;
 use App\UseCases\Recaudo\Comunicados\ListCollectionNoticeRunsUseCase;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
 
 final class CollectionNoticeRunsController extends Controller
 {
@@ -12,12 +17,39 @@ final class CollectionNoticeRunsController extends Controller
     ) {
     }
 
-    public function index(): View
+    public function index(CollectionNoticeRunIndexRequest $request): View
     {
-        $runs = ($this->listCollectionNoticeRuns)();
+        $filtersDto = CollectionNoticeRunFiltersDto::fromArray($request->validated());
+
+        $runs = ($this->listCollectionNoticeRuns)($filtersDto);
 
         return view('recaudo.comunicados.index', [
             'runs' => $runs,
+            'filters' => $filtersDto->toViewData(),
+            'requesters' => $this->requesters(),
+            'types' => $this->noticeTypes(),
         ]);
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    private function requesters(): Collection
+    {
+        return User::query()
+            ->select(['id', 'name'])
+            ->orderBy('name')
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, CollectionNoticeType>
+     */
+    private function noticeTypes(): Collection
+    {
+        return CollectionNoticeType::query()
+            ->select(['id', 'name'])
+            ->orderBy('name')
+            ->get();
     }
 }

--- a/app/Http/Requests/Recaudo/CollectionNoticeRunIndexRequest.php
+++ b/app/Http/Requests/Recaudo/CollectionNoticeRunIndexRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Recaudo;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CollectionNoticeRunIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'requested_by_id' => ['nullable', 'integer', 'exists:users,id'],
+            'collection_notice_type_id' => ['nullable', 'integer', 'exists:collection_notice_types,id'],
+            'date_from' => ['nullable', 'date'],
+            'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'requested_by_id' => $this->nullIfEmpty('requested_by_id'),
+            'collection_notice_type_id' => $this->nullIfEmpty('collection_notice_type_id'),
+            'date_from' => $this->nullIfEmpty('date_from'),
+            'date_to' => $this->nullIfEmpty('date_to'),
+        ]);
+    }
+
+    private function nullIfEmpty(string $key): mixed
+    {
+        $value = $this->input($key);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Repositories/CollectionNoticeRunEloquentRepository.php
+++ b/app/Repositories/CollectionNoticeRunEloquentRepository.php
@@ -5,6 +5,7 @@ namespace App\Repositories;
 use App\Repositories\Interfaces\CollectionNoticeRunRepositoryInterface;
 use App\DTOs\Recaudo\Comunicados\CreateCollectionNoticeRunDto;
 use App\Models\CollectionNoticeRun;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 final class CollectionNoticeRunEloquentRepository implements CollectionNoticeRunRepositoryInterface
 {
@@ -16,5 +17,19 @@ final class CollectionNoticeRunEloquentRepository implements CollectionNoticeRun
             'requested_by'              => $dto->requestedBy,
             'status'                    => 'ready',
         ]);
+    }
+
+    public function paginateWithRelations(int $perPage = 15): LengthAwarePaginator
+    {
+        return CollectionNoticeRun::query()
+            ->with([
+                'type:id,name',
+                'requestedBy:id,name',
+                'files:id,collection_notice_run_id,original_name,notice_data_source_id,uploaded_by,created_at',
+                'files.dataSource:id,name',
+                'files.uploader:id,name',
+            ])
+            ->latest('created_at')
+            ->paginate($perPage);
     }
 }

--- a/app/Repositories/CollectionNoticeRunEloquentRepository.php
+++ b/app/Repositories/CollectionNoticeRunEloquentRepository.php
@@ -2,10 +2,12 @@
 
 namespace App\Repositories;
 
+use App\DTOs\Recaudo\Comunicados\CollectionNoticeRunFiltersDto;
 use App\Repositories\Interfaces\CollectionNoticeRunRepositoryInterface;
 use App\DTOs\Recaudo\Comunicados\CreateCollectionNoticeRunDto;
 use App\Models\CollectionNoticeRun;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
 
 final class CollectionNoticeRunEloquentRepository implements CollectionNoticeRunRepositoryInterface
 {
@@ -19,17 +21,41 @@ final class CollectionNoticeRunEloquentRepository implements CollectionNoticeRun
         ]);
     }
 
-    public function paginateWithRelations(int $perPage = 15): LengthAwarePaginator
+    public function paginateWithRelations(CollectionNoticeRunFiltersDto $filters, int $perPage = 15): LengthAwarePaginator
     {
-        return CollectionNoticeRun::query()
+        $query = CollectionNoticeRun::query()
             ->with([
                 'type:id,name',
                 'requestedBy:id,name',
                 'files:id,collection_notice_run_id,original_name,notice_data_source_id,uploaded_by,created_at',
                 'files.dataSource:id,name',
                 'files.uploader:id,name',
-            ])
+            ]);
+
+        $this->applyFilters($query, $filters);
+
+        return $query
             ->latest('created_at')
-            ->paginate($perPage);
+            ->paginate($perPage)
+            ->appends($filters->toQuery());
+    }
+
+    private function applyFilters(Builder $query, CollectionNoticeRunFiltersDto $filters): void
+    {
+        if ($filters->requestedById !== null) {
+            $query->where('requested_by_id', $filters->requestedById);
+        }
+
+        if ($filters->collectionNoticeTypeId !== null) {
+            $query->where('collection_notice_type_id', $filters->collectionNoticeTypeId);
+        }
+
+        if ($filters->dateFrom !== null) {
+            $query->where('created_at', '>=', $filters->dateFrom);
+        }
+
+        if ($filters->dateTo !== null) {
+            $query->where('created_at', '<=', $filters->dateTo);
+        }
     }
 }

--- a/app/Repositories/Interfaces/CollectionNoticeRunRepositoryInterface.php
+++ b/app/Repositories/Interfaces/CollectionNoticeRunRepositoryInterface.php
@@ -4,8 +4,11 @@ namespace App\Repositories\Interfaces;
 
 use App\DTOs\Recaudo\Comunicados\CreateCollectionNoticeRunDto;
 use App\Models\CollectionNoticeRun;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
 interface CollectionNoticeRunRepositoryInterface
 {
     public function create(CreateCollectionNoticeRunDto $dto): CollectionNoticeRun;
+
+    public function paginateWithRelations(int $perPage = 15): LengthAwarePaginator;
 }

--- a/app/Repositories/Interfaces/CollectionNoticeRunRepositoryInterface.php
+++ b/app/Repositories/Interfaces/CollectionNoticeRunRepositoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories\Interfaces;
 
+use App\DTOs\Recaudo\Comunicados\CollectionNoticeRunFiltersDto;
 use App\DTOs\Recaudo\Comunicados\CreateCollectionNoticeRunDto;
 use App\Models\CollectionNoticeRun;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -10,5 +11,5 @@ interface CollectionNoticeRunRepositoryInterface
 {
     public function create(CreateCollectionNoticeRunDto $dto): CollectionNoticeRun;
 
-    public function paginateWithRelations(int $perPage = 15): LengthAwarePaginator;
+    public function paginateWithRelations(CollectionNoticeRunFiltersDto $filters, int $perPage = 15): LengthAwarePaginator;
 }

--- a/app/UseCases/Recaudo/Comunicados/ListCollectionNoticeRunsUseCase.php
+++ b/app/UseCases/Recaudo/Comunicados/ListCollectionNoticeRunsUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Recaudo\Comunicados;
+
+use App\Repositories\Interfaces\CollectionNoticeRunRepositoryInterface;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+final class ListCollectionNoticeRunsUseCase
+{
+    public function __construct(
+        private readonly CollectionNoticeRunRepositoryInterface $repository,
+    ) {
+    }
+
+    public function __invoke(int $perPage = 15): LengthAwarePaginator
+    {
+        return $this->repository->paginateWithRelations($perPage);
+    }
+}

--- a/app/UseCases/Recaudo/Comunicados/ListCollectionNoticeRunsUseCase.php
+++ b/app/UseCases/Recaudo/Comunicados/ListCollectionNoticeRunsUseCase.php
@@ -2,6 +2,7 @@
 
 namespace App\UseCases\Recaudo\Comunicados;
 
+use App\DTOs\Recaudo\Comunicados\CollectionNoticeRunFiltersDto;
 use App\Repositories\Interfaces\CollectionNoticeRunRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 
@@ -12,8 +13,8 @@ final class ListCollectionNoticeRunsUseCase
     ) {
     }
 
-    public function __invoke(int $perPage = 15): LengthAwarePaginator
+    public function __invoke(CollectionNoticeRunFiltersDto $filters, int $perPage = 15): LengthAwarePaginator
     {
-        return $this->repository->paginateWithRelations($perPage);
+        return $this->repository->paginateWithRelations($filters, $perPage);
     }
 }

--- a/resources/views/recaudo/comunicados/index.blade.php
+++ b/resources/views/recaudo/comunicados/index.blade.php
@@ -19,6 +19,107 @@
                 </div>
 
                 <div class="mt-8 space-y-6">
+                    @php
+                        $filters = $filters ?? [
+                            'requested_by_id' => null,
+                            'collection_notice_type_id' => null,
+                            'date_from' => null,
+                            'date_to' => null,
+                        ];
+                    @endphp
+
+                    <form
+                        method="GET"
+                        action="{{ route('recaudo.comunicados.index') }}"
+                        class="grid grid-cols-1 gap-4 rounded-3xl border border-gray-200 bg-gray-50 p-6 shadow-inner dark:border-gray-700 dark:bg-gray-900/40 desktop:grid-cols-5"
+                    >
+                        <div class="grid gap-2">
+                            <label for="requested_by_id" class="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                                {{ __('Usuario programación') }}
+                            </label>
+                            <select
+                                id="requested_by_id"
+                                name="requested_by_id"
+                                class="w-full rounded-2xl border border-gray-200 bg-white px-4 py-2 text-sm text-gray-700 transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-100"
+                            >
+                                <option value="">{{ __('Todos') }}</option>
+                                @foreach ($requesters ?? [] as $requester)
+                                    <option value="{{ $requester->id }}" @selected((string) $filters['requested_by_id'] === (string) $requester->id)>
+                                        {{ $requester->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div class="grid gap-2">
+                            <label for="collection_notice_type_id" class="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                                {{ __('Tipo de cargue') }}
+                            </label>
+                            <select
+                                id="collection_notice_type_id"
+                                name="collection_notice_type_id"
+                                class="w-full rounded-2xl border border-gray-200 bg-white px-4 py-2 text-sm text-gray-700 transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-100"
+                            >
+                                <option value="">{{ __('Todos') }}</option>
+                                @foreach ($types ?? [] as $type)
+                                    <option value="{{ $type->id }}" @selected((string) $filters['collection_notice_type_id'] === (string) $type->id)>
+                                        {{ $type->name }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div class="grid gap-2 desktop:col-span-2">
+                            <span class="text-xs font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-300">
+                                {{ __('Rango de fechas') }}
+                            </span>
+                            <div class="grid grid-cols-1 gap-3 desktop:grid-cols-2">
+                                <div class="grid gap-1">
+                                    <label for="date_from" class="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                        {{ __('Desde') }}
+                                    </label>
+                                    <input
+                                        type="date"
+                                        id="date_from"
+                                        name="date_from"
+                                        value="{{ $filters['date_from'] }}"
+                                        class="w-full rounded-2xl border border-gray-200 bg-white px-4 py-2 text-sm text-gray-700 transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-100"
+                                    >
+                                </div>
+                                <div class="grid gap-1">
+                                    <label for="date_to" class="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                        {{ __('Hasta') }}
+                                    </label>
+                                    <input
+                                        type="date"
+                                        id="date_to"
+                                        name="date_to"
+                                        value="{{ $filters['date_to'] }}"
+                                        class="w-full rounded-2xl border border-gray-200 bg-white px-4 py-2 text-sm text-gray-700 transition focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-700 dark:bg-gray-900/60 dark:text-gray-100"
+                                    >
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="flex items-end gap-3">
+                            <button
+                                type="submit"
+                                class="inline-flex w-full items-center justify-center gap-2 rounded-3xl bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900"
+                            >
+                                <i class="fa-solid fa-filter"></i>
+                                <span>{{ __('Filtrar') }}</span>
+                            </button>
+
+                            <a
+                                href="{{ route('recaudo.comunicados.index') }}"
+                                class="inline-flex items-center justify-center gap-2 rounded-3xl border border-gray-200 px-5 py-2 text-sm font-semibold text-gray-600 transition hover:border-primary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white dark:border-gray-700 dark:text-gray-300 dark:hover:border-primary"
+                            >
+                                <i class="fa-solid fa-rotate-right"></i>
+                                <span>{{ __('Limpiar') }}</span>
+                            </a>
+                        </div>
+                    </form>
+
                     <div class="grid grid-cols-8 gap-4 rounded-2xl bg-gray-100 px-6 py-3 text-label font-semibold uppercase tracking-wide text-gray-700 dark:bg-gray-900/60 dark:text-gray-200">
                         <span>{{ __('Id Comunicado') }}</span>
                         <span>{{ __('Fecha Programación') }}</span>
@@ -93,7 +194,7 @@
                                             </button>
                                         </div>
 
-                                        <div class="mt-4 space-y-3">
+                                        <div class="mt-4 max-h-64 space-y-3 overflow-y-auto pr-1">
                                             @forelse ($run->files as $file)
                                                 <div class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
                                                     <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $file->original_name }}</p>

--- a/resources/views/recaudo/comunicados/index.blade.php
+++ b/resources/views/recaudo/comunicados/index.blade.php
@@ -19,7 +19,7 @@
                 </div>
 
                 <div class="mt-8 space-y-6">
-                    <div class="grid grid-cols-7 gap-4 rounded-2xl bg-gray-100 px-6 py-3 text-label font-semibold uppercase tracking-wide text-gray-700 dark:bg-gray-900/60 dark:text-gray-200">
+                    <div class="grid grid-cols-8 gap-4 rounded-2xl bg-gray-100 px-6 py-3 text-label font-semibold uppercase tracking-wide text-gray-700 dark:bg-gray-900/60 dark:text-gray-200">
                         <span>{{ __('Id Comunicado') }}</span>
                         <span>{{ __('Fecha Programación') }}</span>
                         <span>{{ __('Usuario Programación') }}</span>
@@ -27,12 +27,115 @@
                         <span>{{ __('Tiempo en Minutos') }}</span>
                         <span>{{ __('Estado') }}</span>
                         <span>{{ __('Resultados') }}</span>
+                        <span class="text-center">{{ __('Archivos') }}</span>
                     </div>
 
-                    <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-gray-300 px-6 py-12 text-center text-body text-gray-500 dark:border-gray-700 dark:text-gray-400">
-                        <i class="fa-regular fa-envelope-open text-2xl text-gray-400"></i>
-                        <p>{{ __('Aún no hay comunicados programados.') }}</p>
-                    </div>
+                    @forelse ($runs ?? [] as $run)
+                        <div class="grid grid-cols-8 items-center gap-4 rounded-2xl border border-gray-200 px-6 py-4 text-body text-gray-700 transition dark:border-gray-700 dark:text-gray-200">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100">#{{ $run->id }}</span>
+                            <span>{{ optional($run->created_at)->format('d/m/Y H:i') ?? __('Sin programación') }}</span>
+                            <span>{{ $run->requestedBy?->name ?? __('No asignado') }}</span>
+                            <span>
+                                @if ($run->started_at)
+                                    {{ $run->started_at->format('d/m/Y H:i') }}
+                                @else
+                                    {{ __('Pendiente') }}
+                                @endif
+                            </span>
+                            <span>
+                                @if ($run->duration_ms)
+                                    {{ (int) ceil($run->duration_ms / 60000) }}
+                                @else
+                                    {{ __('N/D') }}
+                                @endif
+                            </span>
+                            <span class="capitalize">
+                                {{ __($run->status) }}
+                            </span>
+                            <span>
+                                {{ $run->type?->name ?? __('Sin tipo') }}
+                            </span>
+                            <div x-data="{ open: false }" class="relative flex justify-center">
+                                <button
+                                    type="button"
+                                    x-on:click="open = true"
+                                    class="inline-flex items-center justify-center rounded-full bg-primary/10 p-2 text-primary transition hover:bg-primary/20 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900"
+                                    aria-label="{{ __('Ver archivos de insumo') }}"
+                                >
+                                    <i class="fa-solid fa-folder-open text-lg"></i>
+                                    @if ($run->files->isNotEmpty())
+                                        <span class="sr-only">{{ trans_choice(':count archivo|:count archivos', $run->files->count()) }}</span>
+                                    @endif
+                                </button>
+
+                                <div
+                                    x-cloak
+                                    x-show="open"
+                                    x-transition.opacity
+                                    class="fixed inset-0 z-50 flex items-center justify-center"
+                                    aria-modal="true"
+                                    role="dialog"
+                                >
+                                    <div class="absolute inset-0 bg-gray-900/50" x-on:click="open = false"></div>
+
+                                    <div class="relative z-10 w-full max-w-md rounded-3xl bg-white p-6 shadow-2xl dark:bg-gray-800">
+                                        <div class="flex items-center justify-between">
+                                            <h3 class="text-h5 font-semibold text-gray-900 dark:text-gray-100">
+                                                {{ __('Archivos de insumo') }}
+                                            </h3>
+                                            <button
+                                                type="button"
+                                                class="rounded-full p-2 text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                                                x-on:click="open = false"
+                                                aria-label="{{ __('Cerrar') }}"
+                                            >
+                                                <i class="fa-solid fa-xmark"></i>
+                                            </button>
+                                        </div>
+
+                                        <div class="mt-4 space-y-3">
+                                            @forelse ($run->files as $file)
+                                                <div class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+                                                    <p class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $file->original_name }}</p>
+                                                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                        {{ $file->dataSource?->name ?? __('Sin origen') }}
+                                                        •
+                                                        {{ $file->uploader?->name ?? __('Sin usuario') }}
+                                                    </p>
+                                                    <p class="mt-1 text-xs text-gray-400">
+                                                        {{ optional($file->created_at)->format('d/m/Y H:i') ?? __('Sin fecha') }}
+                                                    </p>
+                                                </div>
+                                            @empty
+                                                <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('No hay archivos asignados a este comunicado.') }}</p>
+                                            @endforelse
+                                        </div>
+
+                                        <div class="mt-6 flex justify-end">
+                                            <button
+                                                type="button"
+                                                class="inline-flex items-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-800"
+                                                x-on:click="open = false"
+                                            >
+                                                {{ __('Cerrar') }}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    @empty
+                        <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-gray-300 px-6 py-12 text-center text-body text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                            <i class="fa-regular fa-envelope-open text-2xl text-gray-400"></i>
+                            <p>{{ __('Aún no hay comunicados programados.') }}</p>
+                        </div>
+                    @endforelse
+
+                    @if (($runs ?? null) instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)
+                        <div>
+                            {{ $runs->links() }}
+                        </div>
+                    @endif
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CollectionNoticeRunsController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -17,7 +18,6 @@ Route::middleware([
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {
-    Route::get('/recaudo/comunicados', function () {
-        return view('recaudo.comunicados.index');
-    })->name('recaudo.comunicados.index');
+    Route::get('/recaudo/comunicados', [CollectionNoticeRunsController::class, 'index'])
+        ->name('recaudo.comunicados.index');
 });


### PR DESCRIPTION
## Summary
- add repository pagination contract to expose collection notice runs with eager loaded relations
- introduce use case and controller endpoint to retrieve collection notice runs and feed the comunicados index view
- render collection notice runs grid with files modal on the comunicados page

## Testing
- `php artisan test` *(fails: missing Composer dependencies due to authentication requirement when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_b_68d5731d09e4832c8f5123be7cb44ff2