### PR TITLE
Add deletion use case for collection notice runs

### DIFF
--- a/app/DTOs/Recaudo/Comunicados/CreateCollectionNoticeRunDto.php
+++ b/app/DTOs/Recaudo/Comunicados/CreateCollectionNoticeRunDto.php
@@ -12,7 +12,7 @@ final class CreateCollectionNoticeRunDto
     public function __construct(
         public readonly int $collectionNoticeTypeId,
         public readonly string $periodValue,
-        public readonly int $requestedBy,
+        public readonly int $requestedById,
         public readonly array $files,
     ) {}
 }

--- a/app/DTOs/Recaudo/Comunicados/DeleteCollectionNoticeRunDto.php
+++ b/app/DTOs/Recaudo/Comunicados/DeleteCollectionNoticeRunDto.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\DTOs\Recaudo\Comunicados;
+
+final class DeleteCollectionNoticeRunDto
+{
+    public function __construct(
+        public readonly int $runId,
+    ) {
+    }
+}

--- a/app/DTOs/Recaudo/Comunicados/StoredFileReferenceDto.php
+++ b/app/DTOs/Recaudo/Comunicados/StoredFileReferenceDto.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\DTOs\Recaudo\Comunicados;
+
+final class StoredFileReferenceDto
+{
+    public function __construct(
+        public readonly string $disk,
+        public readonly string $path,
+    ) {
+    }
+}

--- a/app/Enums/Recaudo/CollectionNoticeRunStatus.php
+++ b/app/Enums/Recaudo/CollectionNoticeRunStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\Recaudo;
+
+enum CollectionNoticeRunStatus: string
+{
+    case READY = 'ready';
+    case IN_PROCESS = 'in_process';
+    case FINISHED = 'finished';
+    case CLOSED = 'closed';
+    case CANCELLED = 'cancelled';
+}

--- a/app/Http/Requests/Recaudo/CollectionNoticeRunDestroyRequest.php
+++ b/app/Http/Requests/Recaudo/CollectionNoticeRunDestroyRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Recaudo;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CollectionNoticeRunDestroyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
+++ b/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
@@ -260,7 +260,7 @@ class CreateRunModal extends Component
         $dto = new CreateCollectionNoticeRunDto (
             collectionNoticeTypeId: (int) $this->typeId,
             periodValue: (string) ($this->periodValue ?: $this->period),
-            requestedBy: $userId,
+            requestedById: $userId,
             files: $normalizedFiles,
         );
 

--- a/app/Repositories/CollectionNoticeRunEloquentRepository.php
+++ b/app/Repositories/CollectionNoticeRunEloquentRepository.php
@@ -3,9 +3,10 @@
 namespace App\Repositories;
 
 use App\DTOs\Recaudo\Comunicados\CollectionNoticeRunFiltersDto;
-use App\Repositories\Interfaces\CollectionNoticeRunRepositoryInterface;
 use App\DTOs\Recaudo\Comunicados\CreateCollectionNoticeRunDto;
+use App\Enums\Recaudo\CollectionNoticeRunStatus;
 use App\Models\CollectionNoticeRun;
+use App\Repositories\Interfaces\CollectionNoticeRunRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -16,9 +17,21 @@ final class CollectionNoticeRunEloquentRepository implements CollectionNoticeRun
         return CollectionNoticeRun::query()->create([
             'collection_notice_type_id' => $dto->collectionNoticeTypeId,
             'period_value'              => $dto->periodValue,
-            'requested_by'              => $dto->requestedBy,
-            'status'                    => 'ready',
+            'requested_by_id'           => $dto->requestedById,
+            'status'                    => CollectionNoticeRunStatus::READY->value,
         ]);
+    }
+
+    public function findWithFiles(int $id): ?CollectionNoticeRun
+    {
+        return CollectionNoticeRun::query()
+            ->with(['files:id,collection_notice_run_id,disk,path'])
+            ->find($id);
+    }
+
+    public function delete(CollectionNoticeRun $run): void
+    {
+        $run->delete();
     }
 
     public function paginateWithRelations(CollectionNoticeRunFiltersDto $filters, int $perPage = 15): LengthAwarePaginator

--- a/app/Repositories/Interfaces/CollectionNoticeRunRepositoryInterface.php
+++ b/app/Repositories/Interfaces/CollectionNoticeRunRepositoryInterface.php
@@ -12,4 +12,8 @@ interface CollectionNoticeRunRepositoryInterface
     public function create(CreateCollectionNoticeRunDto $dto): CollectionNoticeRun;
 
     public function paginateWithRelations(CollectionNoticeRunFiltersDto $filters, int $perPage = 15): LengthAwarePaginator;
+
+    public function findWithFiles(int $id): ?CollectionNoticeRun;
+
+    public function delete(CollectionNoticeRun $run): void;
 }

--- a/app/UseCases/Recaudo/Comunicados/CreateCollectionNoticeRunUseCase.php
+++ b/app/UseCases/Recaudo/Comunicados/CreateCollectionNoticeRunUseCase.php
@@ -10,7 +10,6 @@ use App\Models\CollectionNoticeType;
 use App\Models\CollectionNoticeRun;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Database\DatabaseManager;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use RuntimeException;
 
@@ -93,7 +92,7 @@ final class CreateCollectionNoticeRunUseCase
                         mime: $file->getMimeType(),
                         ext: $ext ? strtolower($ext) : null,
                         sha256: $sha256,
-                        uploadedBy: $dto->requestedBy,
+                        uploadedBy: $dto->requestedById,
                     )
                 );
             }

--- a/app/UseCases/Recaudo/Comunicados/DeleteCollectionNoticeRunUseCase.php
+++ b/app/UseCases/Recaudo/Comunicados/DeleteCollectionNoticeRunUseCase.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\UseCases\Recaudo\Comunicados;
+
+use App\DTOs\Recaudo\Comunicados\DeleteCollectionNoticeRunDto;
+use App\DTOs\Recaudo\Comunicados\StoredFileReferenceDto;
+use App\Enums\Recaudo\CollectionNoticeRunStatus;
+use App\Models\CollectionNoticeRun;
+use App\Repositories\Interfaces\CollectionNoticeRunRepositoryInterface;
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use RuntimeException;
+
+final class DeleteCollectionNoticeRunUseCase
+{
+    public function __construct(
+        private readonly CollectionNoticeRunRepositoryInterface $repository,
+        private readonly DatabaseManager $db,
+        private readonly FilesystemFactory $filesystem,
+    ) {
+    }
+
+    public function __invoke(DeleteCollectionNoticeRunDto $dto): void
+    {
+        $run = $this->repository->findWithFiles($dto->runId);
+
+        if ($run === null) {
+            throw (new ModelNotFoundException())->setModel(CollectionNoticeRun::class, [$dto->runId]);
+        }
+
+        if ($run->status !== CollectionNoticeRunStatus::READY->value) {
+            throw new RuntimeException(__('Solo puedes eliminar comunicados en estado listo.'));
+        }
+
+        $fileReferences = $run->files
+            ->map(static fn ($file) => new StoredFileReferenceDto(
+                disk: (string) $file->disk,
+                path: (string) $file->path,
+            ))
+            ->all();
+
+        $this->db->transaction(function () use ($run): void {
+            $this->repository->delete($run);
+        });
+
+        $this->deleteStoredFiles($fileReferences);
+    }
+
+    /**
+     * @param  array<int, StoredFileReferenceDto>  $files
+     */
+    private function deleteStoredFiles(array $files): void
+    {
+        foreach ($files as $file) {
+            $disk = $this->filesystem->disk($file->disk);
+
+            if ($file->path === '') {
+                continue;
+            }
+
+            if ($disk->exists($file->path) && ! $disk->delete($file->path)) {
+                throw new RuntimeException(__('No fue posible eliminar uno de los archivos asociados al comunicado.'));
+            }
+        }
+    }
+}

--- a/resources/views/recaudo/comunicados/index.blade.php
+++ b/resources/views/recaudo/comunicados/index.blade.php
@@ -120,7 +120,7 @@
                         </div>
                     </form>
 
-                    <div class="grid grid-cols-8 gap-4 rounded-2xl bg-gray-100 px-6 py-3 text-label font-semibold uppercase tracking-wide text-gray-700 dark:bg-gray-900/60 dark:text-gray-200">
+                    <div class="grid grid-cols-9 gap-4 rounded-2xl bg-gray-100 px-6 py-3 text-label font-semibold uppercase tracking-wide text-gray-700 dark:bg-gray-900/60 dark:text-gray-200">
                         <span>{{ __('Id Comunicado') }}</span>
                         <span>{{ __('Fecha Programación') }}</span>
                         <span>{{ __('Usuario Programación') }}</span>
@@ -129,10 +129,14 @@
                         <span>{{ __('Estado') }}</span>
                         <span>{{ __('Resultados') }}</span>
                         <span class="text-center">{{ __('Archivos') }}</span>
+                        <span class="text-center">OPERATIONS</span>
                     </div>
 
                     @forelse ($runs ?? [] as $run)
-                        <div class="grid grid-cols-8 items-center gap-4 rounded-2xl border border-gray-200 px-6 py-4 text-body text-gray-700 transition dark:border-gray-700 dark:text-gray-200">
+                        @php
+                            $canDelete = $run->status === \App\Enums\Recaudo\CollectionNoticeRunStatus::READY->value;
+                        @endphp
+                        <div class="grid grid-cols-9 items-center gap-4 rounded-2xl border border-gray-200 px-6 py-4 text-body text-gray-700 transition dark:border-gray-700 dark:text-gray-200">
                             <span class="font-semibold text-gray-900 dark:text-gray-100">#{{ $run->id }}</span>
                             <span>{{ optional($run->created_at)->format('d/m/Y H:i') ?? __('Sin programación') }}</span>
                             <span>{{ $run->requestedBy?->name ?? __('No asignado') }}</span>
@@ -223,6 +227,41 @@
                                         </div>
                                     </div>
                                 </div>
+                            </div>
+
+                            <div class="flex justify-center">
+                                <form
+                                    method="POST"
+                                    action="{{ route('recaudo.comunicados.destroy', $run) }}"
+                                    x-data="{ confirmDelete() { return confirm(@js(__('¿Deseas eliminar este comunicado? Esta acción no se puede deshacer.'))); } }"
+                                >
+                                    @csrf
+                                    @method('DELETE')
+
+                                    <button
+                                        type="submit"
+                                        @click.prevent="
+                                            if (! {{ $canDelete ? 'true' : 'false' }}) {
+                                                return;
+                                            }
+
+                                            if (confirmDelete()) {
+                                                $el.closest('form').submit();
+                                            }
+                                        "
+                                        @disabled(! $canDelete)
+                                        aria-disabled="{{ $canDelete ? 'false' : 'true' }}"
+                                        class="inline-flex items-center justify-center rounded-full p-2 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900 {{
+                                            $canDelete
+                                                ? 'bg-red-100 text-red-600 hover:bg-red-200 focus:ring-red-500'
+                                                : 'cursor-not-allowed bg-gray-200 text-gray-400 dark:bg-gray-700 dark:text-gray-500'
+                                        }}"
+                                        title="{{ $canDelete ? __('Eliminar comunicado') : __('Solo se pueden eliminar comunicados en estado listo.') }}"
+                                    >
+                                        <i class="fa-solid fa-trash"></i>
+                                        <span class="sr-only">{{ __('Eliminar comunicado') }}</span>
+                                    </button>
+                                </form>
                             </div>
                         </div>
                     @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,4 +20,7 @@ Route::middleware([
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/recaudo/comunicados', [CollectionNoticeRunsController::class, 'index'])
         ->name('recaudo.comunicados.index');
+
+    Route::delete('/recaudo/comunicados/{run}', [CollectionNoticeRunsController::class, 'destroy'])
+        ->name('recaudo.comunicados.destroy');
 });


### PR DESCRIPTION
## Summary
- ensure collection notice runs are created with the correct requested_by_id by tightening DTO typing
- add a dedicated use case, DTOs, enum, repository methods, and controller logic to delete runs along with their stored files
- expose the delete action in the Comunicados grid with a new OPERATIONS column and protect it for ready runs only

## Testing
- composer test *(fails: vendor directory is missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d5b2dc63ec832cb97bf0ad459d3d95