### PR TITLE
Refresh comunicados grid after creating new run

### DIFF
--- a/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
+++ b/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
@@ -273,6 +273,7 @@ class CreateRunModal extends Component
             // UX: cerrar, limpiar y notificar
             $this->dispatch('toast', type: 'success', message: __('Trabajo generado correctamente.'));
             $this->cancel();
+            $this->dispatch('collectionNoticeRunCreated');
         } catch (\Throwable $e) {
             report($e);
             $this->addError('general', __('No fue posible crear el trabajo. Intenta de nuevo.'));

--- a/resources/views/recaudo/comunicados/index.blade.php
+++ b/resources/views/recaudo/comunicados/index.blade.php
@@ -282,4 +282,12 @@
     </div>
 
     @livewire('recaudo.comunicados.create-run-modal')
+
+    <script>
+        document.addEventListener('livewire:init', () => {
+            Livewire.on('collectionNoticeRunCreated', () => {
+                window.location.reload();
+            });
+        });
+    </script>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- dispatch a Livewire event when a comunicados run is created successfully
- listen for the Livewire event on the listing page and reload the grid to show the new record

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d69a1152c8832ca94471c14d5e86a6