### PR TITLE
Implement chunked upload workflow for collection notice inputs

### DIFF
--- a/app/DTOs/Recaudo/Comunicados/CreateCollectionNoticeRunDto.php
+++ b/app/DTOs/Recaudo/Comunicados/CreateCollectionNoticeRunDto.php
@@ -2,13 +2,11 @@
 
 namespace App\DTOs\Recaudo\Comunicados;
 
-use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
-
-/**
- * @param array<int, TemporaryUploadedFile> $files  // key: notice_data_source_id
- */
 final class CreateCollectionNoticeRunDto
 {
+    /**
+     * @param array<int, array{path:string, original_name:string, size:int, mime:?string, extension:?string}> $files
+     */
     public function __construct(
         public readonly int $collectionNoticeTypeId,
         public readonly string $periodValue,

--- a/app/DTOs/Recaudo/Comunicados/RunStoredFileDto.php
+++ b/app/DTOs/Recaudo/Comunicados/RunStoredFileDto.php
@@ -13,7 +13,6 @@ final class RunStoredFileDto
         public readonly int $size,
         public readonly ?string $mime,
         public readonly ?string $ext,
-        public readonly ?string $sha256,
         public readonly int $uploadedBy,
     ) {}
 }

--- a/app/Http/Controllers/CollectionNoticeChunkUploadController.php
+++ b/app/Http/Controllers/CollectionNoticeChunkUploadController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Uploads\ChunkedUploadManager;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CollectionNoticeChunkUploadController
+{
+    public function __construct(private readonly ChunkedUploadManager $uploads)
+    {
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'upload_id' => ['required', 'string', 'max:191'],
+            'chunk_index' => ['required', 'integer', 'min:0'],
+            'total_chunks' => ['required', 'integer', 'min:1'],
+            'chunk' => ['required', 'file'],
+            'original_name' => ['nullable', 'string', 'max:255'],
+            'size' => ['nullable', 'integer', 'min:1'],
+            'mime' => ['nullable', 'string', 'max:191'],
+            'extension' => ['nullable', 'string', 'max:30'],
+        ]);
+
+        $metadata = [
+            'original_name' => $validated['original_name'] ?? null,
+            'size' => isset($validated['size']) ? (int) $validated['size'] : null,
+            'mime' => $validated['mime'] ?? null,
+            'extension' => $validated['extension'] ?? null,
+        ];
+
+        $result = $this->uploads->appendChunk(
+            $validated['upload_id'],
+            (int) $validated['chunk_index'],
+            (int) $validated['total_chunks'],
+            $validated['chunk'],
+            $metadata,
+        );
+
+        return response()->json($result);
+    }
+}

--- a/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
+++ b/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
@@ -9,13 +9,9 @@ use Carbon\Carbon;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\On;
 use Livewire\Component;
-use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
-use Livewire\WithFileUploads;
 
 class CreateRunModal extends Component
 {
-    use WithFileUploads;
-
     public bool $open = false;
 
     public ?int $typeId = null;
@@ -51,23 +47,15 @@ class CreateRunModal extends Component
             'period.required' => 'Debes ingresar el periodo en formato YYYYMM.',
             'period.regex' => 'El periodo debe tener formato YYYYMM.',
             'files.*.required' => 'Debes adjuntar el archivo correspondiente a este insumo.',
-            'files.*.file' => 'Adjunta un archivo válido.',
-            'files.*.max' => 'El archivo supera el tamaño máximo permitido (10 MB).',
+            'files.*.array' => 'Adjunta un archivo válido.',
+            'files.*.path.required' => 'La carga del archivo aún no finaliza.',
+            'files.*.path.string' => 'La ruta temporal del archivo es inválida.',
+            'files.*.original_name.required' => 'No se recibió el nombre del archivo cargado.',
+            'files.*.original_name.string' => 'El nombre del archivo es inválido.',
+            'files.*.size.required' => 'No se detectó el tamaño del archivo cargado.',
+            'files.*.size.integer' => 'El tamaño del archivo es inválido.',
+            'files.*.size.min' => 'El archivo debe contener información.',
         ];
-
-        foreach ($this->dataSources as $dataSource) {
-            if (! isset($dataSource['id'])) {
-                continue;
-            }
-
-            $extension = strtolower((string) ($dataSource['extension'] ?? ''));
-            $messages['files.' . $dataSource['id'] . '.mimes'] = match ($extension) {
-                'csv' => 'Formato inválido. Este insumo solo acepta archivos CSV o TXT.',
-                'xls' => 'Formato inválido. Este insumo solo acepta archivos XLS.',
-                'xlsx' => 'Formato inválido. Este insumo solo acepta archivos XLSX o XLS.',
-                default => 'Formato inválido. Este insumo permite archivos CSV, XLS o XLSX.',
-            };
-        }
 
         return $messages;
     }
@@ -161,7 +149,7 @@ class CreateRunModal extends Component
 
             $file = $this->files[$key] ?? null;
 
-            if ($key === '' || ! $file instanceof TemporaryUploadedFile) {
+            if ($key === '' || ! is_array($file) || empty($file['path'])) {
                 return false;
             }
         }
@@ -223,13 +211,83 @@ class CreateRunModal extends Component
             $extension = strtolower((string) ($dataSource['extension'] ?? ''));
             $rules['files.' . $dataSource['id']] = [
                 'required',
-                'file',
-                'mimes:' . $this->mimesFromExtension($extension),
-                'max:10240',
+                'array',
+                function (string $attribute, $value, $fail) use ($extension) {
+                    if (! is_array($value)) {
+                        $fail(__('Adjunta un archivo válido.'));
+
+                        return;
+                    }
+
+                    $providedExtension = strtolower((string) ($value['extension'] ?? ''));
+                    $originalName = (string) ($value['original_name'] ?? '');
+
+                    if ($providedExtension === '') {
+                        $providedExtension = strtolower((string) (pathinfo($originalName, PATHINFO_EXTENSION) ?: ''));
+                    }
+
+                    if ($providedExtension === '') {
+                        $fail(__('Adjunta un archivo con una extensión válida.'));
+
+                        return;
+                    }
+
+                    $allowedExtensions = $this->allowedExtensionsFromRequirement($extension);
+
+                    if (! in_array($providedExtension, $allowedExtensions, true)) {
+                        $fail($this->extensionErrorMessage($extension));
+                    }
+                },
             ];
+
+            $rules['files.' . $dataSource['id'] . '.path'] = ['required', 'string'];
+            $rules['files.' . $dataSource['id'] . '.original_name'] = ['required', 'string'];
+            $rules['files.' . $dataSource['id'] . '.size'] = ['required', 'integer', 'min:1'];
+            $rules['files.' . $dataSource['id'] . '.mime'] = ['nullable', 'string'];
+            $rules['files.' . $dataSource['id'] . '.extension'] = ['nullable', 'string'];
         }
 
         return $rules;
+    }
+
+    #[On('chunk-uploading')]
+    public function handleChunkUploading(array $payload): void
+    {
+        $dataSourceId = isset($payload['dataSourceId']) ? (int) $payload['dataSourceId'] : 0;
+
+        if ($dataSourceId <= 0) {
+            return;
+        }
+
+        unset($this->files[(string) $dataSourceId]);
+        $this->resetErrorBag(['files.' . $dataSourceId]);
+    }
+
+    #[On('chunk-uploaded')]
+    public function handleChunkUploaded(array $payload): void
+    {
+        $dataSourceId = isset($payload['dataSourceId']) ? (int) $payload['dataSourceId'] : 0;
+        $file = $payload['file'] ?? null;
+
+        if ($dataSourceId <= 0 || ! is_array($file)) {
+            return;
+        }
+
+        $path = (string) ($file['path'] ?? '');
+
+        if ($path === '') {
+            return;
+        }
+
+        $this->files[(string) $dataSourceId] = [
+            'path' => $path,
+            'original_name' => (string) ($file['original_name'] ?? ''),
+            'size' => isset($file['size']) ? (int) $file['size'] : 0,
+            'mime' => $file['mime'] ?? null,
+            'extension' => $file['extension'] ?? null,
+        ];
+
+        $this->resetErrorBag(['files.' . $dataSourceId]);
     }
 
     #[On('openCreateRunModal')]
@@ -311,13 +369,23 @@ class CreateRunModal extends Component
         return $year >= 2000 && $month >= 1 && $month <= 12;
     }
 
-    protected function mimesFromExtension(string $extension): string
+    protected function allowedExtensionsFromRequirement(string $extension): array
     {
         return match ($extension) {
-            'csv' => 'csv,txt',
-            'xls' => 'xls',
-            'xlsx' => 'xlsx,xls',
-            default => 'csv,xls,xlsx',
+            'csv' => ['csv', 'txt'],
+            'xls' => ['xls'],
+            'xlsx' => ['xlsx', 'xls'],
+            default => ['csv', 'xls', 'xlsx'],
+        };
+    }
+
+    protected function extensionErrorMessage(string $extension): string
+    {
+        return match ($extension) {
+            'csv' => __('Formato inválido. Este insumo solo acepta archivos CSV o TXT.'),
+            'xls' => __('Formato inválido. Este insumo solo acepta archivos XLS.'),
+            'xlsx' => __('Formato inválido. Este insumo solo acepta archivos XLSX o XLS.'),
+            default => __('Formato inválido. Este insumo permite archivos CSV, XLS o XLSX.'),
         };
     }
 }

--- a/app/Repositories/CollectionNoticeRunFileEloquentRepository.php
+++ b/app/Repositories/CollectionNoticeRunFileEloquentRepository.php
@@ -19,7 +19,6 @@ final class CollectionNoticeRunFileEloquentRepository implements CollectionNotic
             'size'                     => $file->size,
             'mime'                     => $file->mime,
             'ext'                      => $file->ext,
-            'sha256'                   => $file->sha256,
             'uploaded_by'              => $file->uploadedBy,
         ]);
     }

--- a/app/Services/Uploads/ChunkedUploadManager.php
+++ b/app/Services/Uploads/ChunkedUploadManager.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace App\Services\Uploads;
+
+use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class ChunkedUploadManager
+{
+    private const PENDING_DIRECTORY = 'pending';
+    private const COMPLETED_DIRECTORY = 'completed';
+
+    public function __construct(private readonly FilesystemFactory $filesystem)
+    {
+    }
+
+    /**
+     * @param array{original_name:?string, size:?int, mime:?string, extension:?string} $metadata
+     *
+     * @return array{completed: bool, file?: array{path: string, original_name: string, size: int, mime:?string, extension:?string}}
+     */
+    public function appendChunk(string $uploadId, int $chunkIndex, int $totalChunks, UploadedFile $chunk, array $metadata = []): array
+    {
+        $disk = $this->getDisk();
+
+        if ($uploadId === '' || $totalChunks <= 0 || $chunkIndex < 0 || $chunkIndex >= $totalChunks) {
+            throw new RuntimeException('Los datos del chunk recibido son inválidos.');
+        }
+
+        $basePath = $this->buildPendingPath($uploadId);
+        $this->ensureDirectoryExists($disk, $basePath);
+
+        if ($chunkIndex === 0) {
+            $this->storeMetadata($disk, $basePath, $metadata);
+        }
+
+        $chunkName = $this->chunkFileName($chunkIndex);
+
+        $disk->putFileAs($basePath, $chunk, $chunkName);
+
+        if ($chunkIndex + 1 < $totalChunks) {
+            return ['completed' => false];
+        }
+
+        $fileInfo = $this->assembleChunks($disk, $basePath, $uploadId);
+
+        return [
+            'completed' => true,
+            'file' => $fileInfo,
+        ];
+    }
+
+    protected function assembleChunks(Filesystem $disk, string $basePath, string $uploadId): array
+    {
+        $metadata = $this->readMetadata($disk, $basePath);
+
+        $originalName = $metadata['original_name'] ?? 'archivo';
+        $extension = $metadata['extension'] ?? (pathinfo($originalName, PATHINFO_EXTENSION) ?: null);
+        $safeBase = Str::slug(pathinfo($originalName, PATHINFO_FILENAME)) ?: $uploadId;
+        $finalName = $safeBase . ($extension ? '.' . strtolower($extension) : '');
+
+        $targetDirectory = $this->buildCompletedPath($uploadId);
+        $this->ensureDirectoryExists($disk, $targetDirectory);
+        $targetPath = $targetDirectory . '/' . $finalName;
+
+        $absoluteTarget = $disk->path($targetPath);
+        $targetHandle = fopen($absoluteTarget, 'w+b');
+
+        if ($targetHandle === false) {
+            throw new RuntimeException('No fue posible abrir el archivo de destino para completar la carga.');
+        }
+
+        $chunkFiles = array_filter(
+            $disk->files($basePath),
+            static fn (string $file) => str_ends_with($file, '.part')
+        );
+
+        sort($chunkFiles);
+
+        foreach ($chunkFiles as $chunkPath) {
+            $sourceHandle = fopen($disk->path($chunkPath), 'rb');
+
+            if ($sourceHandle === false) {
+                fclose($targetHandle);
+                throw new RuntimeException('No fue posible leer un fragmento del archivo para completarlo.');
+            }
+
+            stream_copy_to_stream($sourceHandle, $targetHandle);
+            fclose($sourceHandle);
+        }
+
+        fflush($targetHandle);
+        fclose($targetHandle);
+
+        foreach ($chunkFiles as $chunkPath) {
+            $disk->delete($chunkPath);
+        }
+
+        $disk->delete($basePath . '/meta.json');
+        $disk->deleteDirectory($basePath);
+
+        $size = $metadata['size'] ?? null;
+        if (! $size) {
+            $size = (int) $disk->size($targetPath);
+        }
+
+        return [
+            'path' => $targetPath,
+            'original_name' => $originalName,
+            'size' => (int) $size,
+            'mime' => $metadata['mime'] ?? null,
+            'extension' => $extension ? strtolower($extension) : null,
+        ];
+    }
+
+    protected function storeMetadata(Filesystem $disk, string $basePath, array $metadata): void
+    {
+        $payload = json_encode([
+            'original_name' => $metadata['original_name'] ?? null,
+            'size' => isset($metadata['size']) ? (int) $metadata['size'] : null,
+            'mime' => $metadata['mime'] ?? null,
+            'extension' => $metadata['extension'] ?? null,
+        ], JSON_THROW_ON_ERROR);
+
+        $disk->put($basePath . '/meta.json', $payload);
+    }
+
+    /**
+     * @return array{original_name:?string, size:?int, mime:?string, extension:?string}
+     */
+    protected function readMetadata(Filesystem $disk, string $basePath): array
+    {
+        $metaPath = $basePath . '/meta.json';
+
+        if (! $disk->exists($metaPath)) {
+            return [
+                'original_name' => null,
+                'size' => null,
+                'mime' => null,
+                'extension' => null,
+            ];
+        }
+
+        $contents = $disk->get($metaPath);
+
+        try {
+            /** @var array{original_name:?string, size:?int, mime:?string, extension:?string} $decoded */
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            Log::warning('No fue posible leer los metadatos de una carga fragmentada.', [
+                'upload' => $basePath,
+                'exception' => $e,
+            ]);
+
+            return [
+                'original_name' => null,
+                'size' => null,
+                'mime' => null,
+                'extension' => null,
+            ];
+        }
+
+        return $decoded;
+    }
+
+    protected function chunkFileName(int $chunkIndex): string
+    {
+        return str_pad((string) $chunkIndex, 6, '0', STR_PAD_LEFT) . '.part';
+    }
+
+    protected function buildPendingPath(string $uploadId): string
+    {
+        return self::PENDING_DIRECTORY . '/' . $uploadId;
+    }
+
+    protected function buildCompletedPath(string $uploadId): string
+    {
+        return self::COMPLETED_DIRECTORY . '/' . $uploadId;
+    }
+
+    protected function getDisk(): Filesystem
+    {
+        return $this->filesystem->disk('collection_temp');
+    }
+
+    protected function ensureDirectoryExists(Filesystem $disk, string $path): void
+    {
+        if ($path === '') {
+            return;
+        }
+
+        if (method_exists($disk, 'ensureDirectoryExists')) {
+            $disk->ensureDirectoryExists($path);
+
+            return;
+        }
+
+        $disk->makeDirectory($path);
+    }
+}

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -64,6 +64,12 @@ return [
             'root' => storage_path('app/collection'),
             'throw' => true,
         ],
+
+        'collection_temp' => [
+            'driver' => 'local',
+            'root' => storage_path('app/collection_tmp'),
+            'throw' => true,
+        ],
     ],
 
     /*

--- a/database/migrations/2025_09_25_143743_drop_sha256_from_collection_notice_run_files_table.php
+++ b/database/migrations/2025_09_25_143743_drop_sha256_from_collection_notice_run_files_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('collection_notice_run_files', 'sha256')) {
+            return;
+        }
+
+        Schema::table('collection_notice_run_files', function (Blueprint $table) {
+            $table->dropColumn('sha256');
+        });
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('collection_notice_run_files', 'sha256')) {
+            return;
+        }
+
+        Schema::table('collection_notice_run_files', function (Blueprint $table) {
+            $table->string('sha256', 64)->nullable();
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,8 +3,11 @@ import '../css/app.css';
 
 import collapse from '@alpinejs/collapse';
 import focus from '@alpinejs/focus';
+import { collectionRunUploader } from './modules/collection-run-chunk-uploader';
 
 document.addEventListener('alpine:init', () => {
     window.Alpine.plugin(collapse);
     window.Alpine.plugin(focus);
 });
+
+window.collectionRunUploader = collectionRunUploader;

--- a/resources/js/modules/collection-run-chunk-uploader.js
+++ b/resources/js/modules/collection-run-chunk-uploader.js
@@ -1,0 +1,170 @@
+import axios from 'axios';
+
+const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024;
+
+export function collectionRunUploader(options) {
+    return {
+        fileName: options.initialFile?.original_name ?? '',
+        fileSize: options.initialFile?.size ?? 0,
+        progress: 0,
+        isUploading: false,
+        status: options.initialFile ? 'completed' : 'idle',
+        errorMessage: '',
+        uploadId: null,
+        handleFileSelected(event) {
+            const file = event.target.files?.[0];
+
+            if (!file) {
+                return;
+            }
+
+            event.target.value = '';
+
+            this.errorMessage = '';
+            this.fileName = file.name;
+            this.fileSize = file.size;
+            this.progress = 0;
+            this.isUploading = true;
+            this.status = 'uploading';
+            this.uploadId = generateUploadId();
+
+            if (window.Livewire) {
+                window.Livewire.dispatch('chunk-uploading', { dataSourceId: options.dataSourceId });
+            }
+
+            uploadFileInChunks({
+                file,
+                uploadId: this.uploadId,
+                url: options.uploadUrl,
+                chunkSize: options.chunkSize ?? DEFAULT_CHUNK_SIZE,
+                onProgress: (value) => {
+                    this.progress = value;
+                },
+            })
+                .then((response) => {
+                    this.isUploading = false;
+                    this.status = 'completed';
+                    this.progress = 100;
+
+                    const uploadedFile = response.file ?? {};
+                    this.fileName = uploadedFile.original_name ?? file.name;
+                    this.fileSize = uploadedFile.size ?? file.size;
+
+                    if (window.Livewire) {
+                        window.Livewire.dispatch('chunk-uploaded', {
+                            dataSourceId: options.dataSourceId,
+                            file: uploadedFile,
+                        });
+                    }
+                })
+                .catch((error) => {
+                    this.isUploading = false;
+                    this.status = 'error';
+                    this.progress = 0;
+
+                    const message = extractErrorMessage(error);
+                    this.errorMessage = message;
+
+                    if (window.Livewire) {
+                        window.Livewire.dispatch('toast', { type: 'error', message });
+                    }
+                });
+        },
+        progressLabel() {
+            if (this.isUploading) {
+                return `${Math.round(this.progress)}%`;
+            }
+
+            if (this.status === 'completed' && this.fileSize) {
+                return humanFileSize(this.fileSize);
+            }
+
+            return '';
+        },
+    };
+}
+
+async function uploadFileInChunks({ file, uploadId, url, chunkSize, onProgress }) {
+    const size = Math.max(chunkSize, 512 * 1024);
+    const totalChunks = Math.max(1, Math.ceil(file.size / size));
+
+    for (let index = 0; index < totalChunks; index += 1) {
+        const start = index * size;
+        const end = Math.min(file.size, start + size);
+        const chunk = file.slice(start, end);
+
+        const formData = new FormData();
+        formData.append('upload_id', uploadId);
+        formData.append('chunk_index', index.toString());
+        formData.append('total_chunks', totalChunks.toString());
+        formData.append('chunk', chunk, file.name);
+
+        if (index === 0) {
+            formData.append('original_name', file.name);
+            formData.append('size', file.size.toString());
+            formData.append('mime', file.type);
+
+            const extension = file.name.includes('.') ? file.name.split('.').pop() : '';
+            if (extension) {
+                formData.append('extension', extension.toLowerCase());
+            }
+        }
+
+        const response = await axios.post(url, formData, {
+            onUploadProgress: (event) => {
+                if (event.total) {
+                    const chunkProgress = event.loaded / event.total;
+                    const globalProgress = ((index + chunkProgress) / totalChunks) * 100;
+                    onProgress?.(Math.min(globalProgress, 100));
+                }
+            },
+        });
+
+        if (typeof onProgress === 'function') {
+            onProgress(((index + 1) / totalChunks) * 100);
+        }
+
+        if (response?.data?.completed) {
+            return response.data;
+        }
+    }
+
+    throw new Error('La respuesta del servidor no es válida.');
+}
+
+function extractErrorMessage(error) {
+    if (error.response?.data?.message) {
+        return error.response.data.message;
+    }
+
+    if (typeof error.message === 'string' && error.message.trim() !== '') {
+        return error.message;
+    }
+
+    return 'No fue posible cargar el archivo. Intenta de nuevo.';
+}
+
+function humanFileSize(bytes) {
+    if (!bytes || Number.isNaN(bytes)) {
+        return '';
+    }
+
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let value = bytes;
+    let unitIndex = 0;
+
+    while (value >= 1024 && unitIndex < units.length - 1) {
+        value /= 1024;
+        unitIndex += 1;
+    }
+
+    return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function generateUploadId() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+
+    return 'upload-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\CollectionNoticeChunkUploadController;
 use App\Http\Controllers\CollectionNoticeRunsController;
 use Illuminate\Support\Facades\Route;
 
@@ -23,4 +24,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::delete('/recaudo/comunicados/{run}', [CollectionNoticeRunsController::class, 'destroy'])
         ->name('recaudo.comunicados.destroy');
+
+    Route::post('/recaudo/comunicados/uploads/chunk', [CollectionNoticeChunkUploadController::class, 'store'])
+        ->name('recaudo.comunicados.uploads.chunk');
 });


### PR DESCRIPTION
## Summary
- add a chunked upload endpoint and service to assemble large files and store temporary metadata only
- update the collection notice run creation flow to consume uploaded file metadata and persist basic information without hashes
- enhance the Livewire modal and front-end assets to drive chunked uploads with a progress indicator for each required input

## Testing
- `phpunit` *(fails: vendor tree missing in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d6a7df69dc832c9b34127b83992e42