### PR TITLE
Mejora el manejo de cargas fragmentadas en comunicados

### DIFF
--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -165,8 +165,20 @@
                                             </div>
 
                                             @if ($selectedFile)
+                                                @php
+                                                    $displayName = null;
+
+                                                    if (is_array($selectedFile)) {
+                                                        $displayName = $selectedFile['original_name'] ?? null;
+                                                    } elseif (method_exists($selectedFile, 'getClientOriginalName')) {
+                                                        $displayName = $selectedFile->getClientOriginalName();
+                                                    } else {
+                                                        $displayName = (string) $selectedFile;
+                                                    }
+                                                @endphp
+
                                                 <p class="max-w-full truncate rounded-3xl bg-gray-100 px-3 py-1 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                                                    {{ method_exists($selectedFile, 'getClientOriginalName') ? $selectedFile->getClientOriginalName() : (string) $selectedFile }}
+                                                    {{ $displayName ?: __('Archivo seleccionado') }}
                                                 </p>
                                             @endif
 


### PR DESCRIPTION
## Summary
- Normaliza los eventos de carga fragmentada en el modal de comunicados para almacenar los archivos temporales en el disco de colección y validar tamaño, extensión y ruta.
- Ajusta la visualización del nombre del archivo seleccionado en la vista para soportar estructuras de metadatos devueltas por las cargas en chunks.

## Testing
- `composer test` *(falla: es necesario instalar las dependencias de Composer)*

------
https://chatgpt.com/codex/tasks/task_b_68d6fba416e4832c9d25b192a96f8044