### PR TITLE
Ajusta chunk uploads de comunicados

### DIFF
--- a/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
+++ b/app/Livewire/Recaudo/Comunicados/CreateRunModal.php
@@ -210,6 +210,7 @@ class CreateRunModal extends Component
     public function handleCollectionRunChunkUploaded(int $dataSourceId, array $file): void
     {
         if ($dataSourceId <= 0) {
+            $this->skipRender();
             return;
         }
 
@@ -226,6 +227,7 @@ class CreateRunModal extends Component
 
             report($exception);
 
+            $this->skipRender();
             return;
         }
 
@@ -234,6 +236,7 @@ class CreateRunModal extends Component
                 'payload_keys' => array_keys($file),
             ]);
 
+            $this->skipRender();
             return;
         }
 
@@ -249,16 +252,22 @@ class CreateRunModal extends Component
 
             report($exception);
 
+            $this->skipRender();
             return;
         }
 
+        // Guarda metadata para validación/backoffice
         $this->storeUploadedFileMetadata($dataSourceId, $normalized);
 
         $this->logChunkActivity('uploaded', $dataSourceId, [
             'temporary_filename' => $uploadedFile->getFilename(),
-            'filesize' => $uploadedFile->getSize(),
+            'filesize'           => $uploadedFile->getSize(),
         ]);
+
+        $this->skipRender();
     }
+
+
 
     protected function rules(): array
     {

--- a/config/chunked-uploads.php
+++ b/config/chunked-uploads.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'collection_notices' => [
+        'chunk_size' => (int) env('COLLECTION_NOTICE_CHUNK_SIZE', 1024 * 1024 * 2),
+    ],
+];

--- a/resources/js/modules/collection-run-chunk-uploader.js
+++ b/resources/js/modules/collection-run-chunk-uploader.js
@@ -208,8 +208,8 @@ export function collectionRunUploader(options) {
             this.isUploading = true;
             this.uploadId = generateUploadId();
 
-            this.dispatchLivewireEvent('collection-run::chunkUploading', { dataSourceId: this.dataSourceId });
-            this.dispatchLivewireEvent('chunk-uploading', { dataSourceId: this.dataSourceId });
+            //this.dispatchLivewireEvent('collection-run::chunkUploading', { dataSourceId: this.dataSourceId });
+            //this.dispatchLivewireEvent('chunk-uploading', { dataSourceId: this.dataSourceId });
 
             try {
                 const session = new ChunkedUploadSession({

--- a/resources/js/modules/collection-run-chunk-uploader.js
+++ b/resources/js/modules/collection-run-chunk-uploader.js
@@ -1,13 +1,16 @@
 import axios from 'axios';
 
-const FIVE_MEGABYTES = 5 * 1024 * 1024;
-const DEFAULT_CHUNK_SIZE = FIVE_MEGABYTES;
+const ONE_MEGABYTE = 1024 * 1024;
+const MAX_CHUNK_SIZE = 5 * ONE_MEGABYTE;
+const DEFAULT_CHUNK_SIZE = 2 * ONE_MEGABYTE;
+const MIN_CHUNK_SIZE = 256 * 1024;
 
-let livewireChunkSizeConfigured = false;
+let desiredLivewireChunkSize = DEFAULT_CHUNK_SIZE;
+let configuredLivewireChunkSize = null;
 
 if (typeof document !== 'undefined') {
     document.addEventListener('livewire:init', () => {
-        configureLivewireChunkSize();
+        attemptConfigureLivewireChunkSize();
     });
 }
 
@@ -171,7 +174,7 @@ export function collectionRunUploader(options) {
         currentSession: null,
 
         init() {
-            configureLivewireChunkSize();
+            configureLivewireChunkSize(this.chunkSize);
 
             if (this.fileData) {
                 this.applyUploadedFile(this.fileData);
@@ -302,8 +305,7 @@ export function collectionRunUploader(options) {
             }
 
             const normalized = clamp(value, 0, 100);
-            console.log('Progress update:', normalized);
-            this.progress = normalized;
+            this.progress = Math.max(this.progress, normalized);
         },
 
         cancelOngoingUpload() {
@@ -477,20 +479,35 @@ function resolveChunkSize(value) {
         return DEFAULT_CHUNK_SIZE;
     }
 
-    return Math.max(Math.min(numericValue, DEFAULT_CHUNK_SIZE), DEFAULT_CHUNK_SIZE);
+    return clamp(numericValue, MIN_CHUNK_SIZE, MAX_CHUNK_SIZE);
 }
 
-function configureLivewireChunkSize() {
-    if (livewireChunkSizeConfigured || typeof window === 'undefined') {
+function configureLivewireChunkSize(preferredSize = DEFAULT_CHUNK_SIZE) {
+    const normalized = resolveChunkSize(preferredSize);
+
+    if (desiredLivewireChunkSize === normalized) {
+        attemptConfigureLivewireChunkSize();
+
+        return;
+    }
+
+    desiredLivewireChunkSize = normalized;
+    attemptConfigureLivewireChunkSize();
+}
+
+function attemptConfigureLivewireChunkSize() {
+    if (typeof window === 'undefined' || configuredLivewireChunkSize === desiredLivewireChunkSize) {
         return;
     }
 
     const { Livewire } = window;
 
-    if (Livewire && typeof Livewire.setUploadChunkSize === 'function') {
-        Livewire.setUploadChunkSize(DEFAULT_CHUNK_SIZE);
-        livewireChunkSizeConfigured = true;
+    if (!Livewire || typeof Livewire.setUploadChunkSize !== 'function') {
+        return;
     }
+
+    Livewire.setUploadChunkSize(desiredLivewireChunkSize);
+    configuredLivewireChunkSize = desiredLivewireChunkSize;
 }
 
 function generateUploadId() {

--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -97,6 +97,7 @@
                                                 x-data="collectionRunUploader({
                                                     dataSourceId: {{ $dataSource['id'] }},
                                                     uploadUrl: '{{ route('recaudo.comunicados.uploads.chunk') }}',
+                                                    chunkSize: @js((int) config('chunked-uploads.collection_notices.chunk_size')),
                                                     initialFile: @js(is_array($selectedFile) ? $selectedFile : null),
                                                 })"
                                                 x-init="(() => { init(); $el.addEventListener('alpine:destroy', () => destroy(), { once: true }); })()"

--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -81,16 +81,19 @@
                                         wire:key="data-source-{{ $dataSource['id'] }}"
                                         class="grid grid-cols-12 items-start gap-3 py-4 text-sm text-gray-700 dark:text-gray-200"
                                     >
+                                        <!-- Nombre y código -->
                                         <div class="col-span-12 space-y-1 text-sm tablet:col-span-6 desktop:col-span-6">
                                             <p class="font-semibold text-gray-900 dark:text-gray-100">
                                                 {{ $dataSource['name'] }} - {{ $dataSource['code'] }}
                                             </p>
                                         </div>
 
+                                        <!-- Tipo archivo -->
                                         <div class="col-span-12 text-xs uppercase tracking-wide text-gray-600 dark:text-gray-400 tablet:col-span-3 desktop:col-span-3">
                                             {{ $dataSource['extension'] ? strtoupper($dataSource['extension']) : __('N/A') }}
                                         </div>
 
+                                        <!-- Uploader -->
                                         <div class="col-span-12 space-y-2 tablet:col-span-3 desktop:col-span-3">
                                             <div
                                                 class="space-y-2"
@@ -102,8 +105,9 @@
                                                 })"
                                                 x-init="(() => { init(); $el.addEventListener('alpine:destroy', () => destroy(), { once: true }); })()"
                                                 :class="{ 'opacity-60': isUploading }"
-                                                wire:ignore
+                                                wire:ignore.self
                                             >
+                                                <!-- Botón seleccionar -->
                                                 <label
                                                     for="file-{{ $dataSource['id'] }}"
                                                     class="inline-flex w-full items-center justify-center gap-2 rounded-3xl border border-primary-300 bg-white px-4 py-2 text-sm font-semibold text-primary-900 shadow-sm transition hover:border-primary-500 hover:bg-primary-200/60 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-gray-600 dark:bg-gray-900 dark:text-primary-200 dark:focus-within:ring-offset-gray-900 tablet:w-auto"
@@ -122,21 +126,24 @@
                                                     />
                                                 </label>
 
-                                                <div x-show="fileName" x-cloak class="space-y-1">
+                                                <!-- Barra de progreso -->
+                                                <div x-show="isUploading" x-cloak class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                                                    <div
+                                                        class="h-full bg-primary-500 transition-all duration-200 ease-linear"
+                                                        :style="`width: ${progress}%`"
+                                                    ></div>
+                                                </div>
+
+                                                <!-- Nombre solo cuando termine -->
+                                                <div x-show="status === 'completed'" x-cloak>
                                                     <div class="flex w-full items-center justify-between gap-2 rounded-3xl bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
                                                         <span class="max-w-[70%] truncate" x-text="fileName"></span>
                                                         <span class="whitespace-nowrap" x-text="progressLabel()"></span>
                                                     </div>
-
-                                                    <div x-show="isUploading || status === 'completed'" x-cloak class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-                                                        <div
-                                                            class="h-full bg-primary-500 transition-all duration-200 ease-linear"
-                                                            :style="`width: ${progress}%`"
-                                                        ></div>
-                                                    </div>
-
-                                                    <p x-show="status === 'error' && errorMessage" x-cloak class="text-xs font-semibold text-danger" x-text="errorMessage"></p>
                                                 </div>
+
+                                                <!-- Error -->
+                                                <p x-show="status === 'error' && errorMessage" x-cloak class="text-xs font-semibold text-danger" x-text="errorMessage"></p>
                                             </div>
 
                                             @error('files.' . $dataSource['id'])


### PR DESCRIPTION
## Summary
- Permite configurar el tamaño de los fragmentos de carga para comunicados desde la configuración de la aplicación.
- Ajusta el uploader en Alpine para respetar el tamaño configurado y mantener la barra de progreso actualizada.
- Expone el tamaño de fragmento configurado al componente Livewire para sincronizarlo con Livewire.

## Testing
- npm run build *(falla: dependencia @alpinejs/collapse no disponible en el registro de npm en este entorno)*

------
https://chatgpt.com/codex/tasks/task_b_68d720cf7038832c8aafcc3547605837