### PR TITLE
Prevent chunk uploader container from receiving DOM patches

### DIFF
--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -105,7 +105,7 @@
                                                 })"
                                                 x-init="(() => { init(); $el.addEventListener('alpine:destroy', () => destroy(), { once: true }); })()"
                                                 :class="{ 'opacity-60': isUploading }"
-                                                wire:ignore.self
+                                                wire:ignore
                                             >
                                                 <!-- Botón seleccionar -->
                                                 <label


### PR DESCRIPTION
## Summary
- replace the uploader container's `wire:ignore.self` with `wire:ignore` so Livewire skips DOM patches during chunked uploads

## Testing
- not run (not feasible in container)


------
https://chatgpt.com/codex/tasks/task_b_68dabd4e9270832c9e98021b2491df1f