### PR TITLE
Extract reusable uploader for comunicados inputs

### DIFF
--- a/app/DTOs/Recaudo/Comunicados/DataSourceUploadDto.php
+++ b/app/DTOs/Recaudo/Comunicados/DataSourceUploadDto.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\DTOs\Recaudo\Comunicados;
+
+final class DataSourceUploadDto
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+        public readonly string $code,
+        public readonly ?string $extension,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    public static function fromArray(array $attributes): self
+    {
+        $id = isset($attributes['id']) ? (int) $attributes['id'] : 0;
+        $name = isset($attributes['name']) ? (string) $attributes['name'] : '';
+        $code = isset($attributes['code']) ? (string) $attributes['code'] : '';
+        $extension = isset($attributes['extension']) && $attributes['extension'] !== null
+            ? (string) $attributes['extension']
+            : null;
+
+        return new self($id, $name, $code, $extension);
+    }
+}

--- a/app/View/Components/Recaudo/Comunicados/DataSourceUploader.php
+++ b/app/View/Components/Recaudo/Comunicados/DataSourceUploader.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\View\Components\Recaudo\Comunicados;
+
+use App\DTOs\Recaudo\Comunicados\DataSourceUploadDto;
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\View\Component;
+
+class DataSourceUploader extends Component
+{
+    private const DEFAULT_ACCEPTED_EXTENSIONS = ['csv', 'txt', 'xls', 'xlsx'];
+
+    public readonly DataSourceUploadDto $dataSource;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    public readonly ?array $selectedFile;
+
+    public readonly string $uploadUrl;
+
+    public readonly int $chunkSize;
+
+    public readonly int $maxFileSize;
+
+    public readonly string $inputId;
+
+    public readonly string $accept;
+
+    /**
+     * @param array<string, mixed>|null $selectedFile
+     */
+    public function __construct(
+        DataSourceUploadDto $dataSource,
+        ?array $selectedFile = null,
+        string $uploadUrl = '',
+        int $chunkSize = 0,
+        int $maxFileSize = 0,
+        ?array $allowedExtensions = null,
+    ) {
+        $this->dataSource = $dataSource;
+        $this->selectedFile = $this->sanitizeSelectedFile($selectedFile);
+        $this->uploadUrl = $uploadUrl;
+        $this->chunkSize = $chunkSize;
+        $this->maxFileSize = $maxFileSize;
+        $this->inputId = 'file-' . $this->dataSource->id;
+        $this->accept = $this->buildAcceptAttribute($allowedExtensions);
+    }
+
+    public function render(): View|Closure|string
+    {
+        return view('components.recaudo.comunicados.data-source-uploader');
+    }
+
+    /**
+     * @param array<string, mixed>|null $file
+     *
+     * @return array{path:string, original_name:string, size:int, mime:?string, extension:?string}|null
+     */
+    private function sanitizeSelectedFile(?array $file): ?array
+    {
+        if ($file === null) {
+            return null;
+        }
+
+        $path = Arr::get($file, 'path');
+        $originalName = Arr::get($file, 'original_name');
+        $size = Arr::get($file, 'size');
+
+        if (! is_string($path) || $path === '' || ! is_string($originalName) || $originalName === '') {
+            return null;
+        }
+
+        $sizeValue = is_numeric($size) ? (int) $size : 0;
+
+        if ($sizeValue <= 0) {
+            return null;
+        }
+
+        $mime = Arr::get($file, 'mime');
+        $extension = Arr::get($file, 'extension');
+
+        return [
+            'path' => $path,
+            'original_name' => $originalName,
+            'size' => $sizeValue,
+            'mime' => is_string($mime) ? $mime : null,
+            'extension' => is_string($extension) ? Str::lower($extension) : null,
+        ];
+    }
+
+    private function buildAcceptAttribute(?array $allowedExtensions = null): string
+    {
+        $extensions = $allowedExtensions !== null
+            ? $this->normalizeExtensionArray($allowedExtensions)
+            : $this->resolveAllowedExtensions();
+
+        if (empty($extensions)) {
+            $extensions = self::DEFAULT_ACCEPTED_EXTENSIONS;
+        }
+
+        $uniqueExtensions = [];
+
+        foreach ($extensions as $extension) {
+            $normalized = Str::start(Str::lower($extension), '.');
+
+            if (! in_array($normalized, $uniqueExtensions, true)) {
+                $uniqueExtensions[] = $normalized;
+            }
+        }
+
+        return implode(',', $uniqueExtensions);
+    }
+
+    /**
+     * @param array<int, string> $extensions
+     *
+     * @return array<int, string>
+     */
+    private function normalizeExtensionArray(array $extensions): array
+    {
+        return array_values(array_filter(array_map(static function ($value) {
+            if (! is_string($value)) {
+                return null;
+            }
+
+            $normalized = Str::lower(trim($value));
+
+            return $normalized !== '' ? $normalized : null;
+        }, $extensions)));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveAllowedExtensions(): array
+    {
+        $extension = Str::lower((string) ($this->dataSource->extension ?? ''));
+
+        return match ($extension) {
+            'csv' => ['csv', 'txt', 'xls', 'xlsx'],
+            'xls' => ['xls'],
+            'xlsx' => ['xlsx', 'xls'],
+            'txt' => ['txt', 'csv'],
+            default => self::DEFAULT_ACCEPTED_EXTENSIONS,
+        };
+    }
+}

--- a/resources/views/components/recaudo/comunicados/data-source-uploader.blade.php
+++ b/resources/views/components/recaudo/comunicados/data-source-uploader.blade.php
@@ -1,0 +1,82 @@
+@php
+    use Illuminate\Support\Str;
+@endphp
+
+<div
+    {{ $attributes->class(['grid grid-cols-12 items-start gap-3 py-4 text-sm text-gray-700 dark:text-gray-200']) }}
+>
+    <div class="col-span-12 space-y-1 text-sm tablet:col-span-6 desktop:col-span-6">
+        <p class="font-semibold text-gray-900 dark:text-gray-100">
+            {{ $dataSource->name }} - {{ $dataSource->code }}
+        </p>
+    </div>
+
+    <div class="col-span-12 text-xs uppercase tracking-wide text-gray-600 dark:text-gray-400 tablet:col-span-3 desktop:col-span-3">
+        {{ $dataSource->extension ? Str::upper($dataSource->extension) : __('N/A') }}
+    </div>
+
+    <div class="col-span-12 space-y-2 tablet:col-span-3 desktop:col-span-3">
+        <div
+            class="space-y-2"
+            x-data="collectionRunUploader({
+                dataSourceId: {{ $dataSource->id }},
+                uploadUrl: @js($uploadUrl),
+                chunkSize: @js($chunkSize),
+                initialFile: @js($selectedFile),
+                maxFileSize: @js($maxFileSize),
+            })"
+            x-init="(() => { init(); $el.addEventListener('alpine:destroy', () => destroy(), { once: true }); })()"
+            :class="{ 'opacity-60': isUploading }"
+            wire:ignore
+        >
+            <label
+                for="{{ $inputId }}"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-3xl border border-primary-300 bg-white px-4 py-2 text-sm font-semibold text-primary-900 shadow-sm transition hover:border-primary-500 hover:bg-primary-200/60 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-gray-600 dark:bg-gray-900 dark:text-primary-200 dark:focus-within:ring-offset-gray-900 tablet:w-auto"
+                :class="{ 'cursor-not-allowed': isUploading }"
+            >
+                <i class="fa-solid fa-upload"></i>
+                <span>{{ __('Seleccionar archivo') }}</span>
+                <input
+                    id="{{ $inputId }}"
+                    name="files[{{ $dataSource->id }}]"
+                    type="file"
+                    accept="{{ $accept }}"
+                    x-ref="fileInput"
+                    @change="handleFileSelected($event)"
+                    :disabled="isUploading"
+                    class="sr-only"
+                />
+            </label>
+
+            <button
+                type="button"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-3xl border border-danger bg-white px-4 py-2 text-xs font-semibold text-danger shadow-sm transition hover:bg-danger/10 focus:outline-none focus:ring-2 focus:ring-danger focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:border-danger/60 dark:bg-gray-900 dark:text-danger-200 dark:hover:bg-danger/20 dark:focus:ring-offset-gray-900 tablet:w-auto"
+                x-show="isUploading || status === 'completed'"
+                x-cloak
+                @click="cancelUpload()"
+                :disabled="isUploading && !currentSession"
+            >
+                <i :class="isUploading ? 'fa-solid fa-ban' : 'fa-solid fa-xmark'"></i>
+                <span x-text="isUploading ? '{{ __('Cancelar carga') }}' : '{{ __('Quitar archivo') }}'"></span>
+            </button>
+
+            <div x-show="isUploading" x-cloak class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                <div
+                    class="h-full bg-primary-500 transition-all duration-200 ease-linear"
+                    :style="`width: ${progress}%`"
+                ></div>
+            </div>
+
+            <div x-show="status === 'completed'" x-cloak>
+                <div class="flex w-full items-center justify-between gap-2 rounded-3xl bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                    <span class="max-w-[70%] truncate" x-text="fileName"></span>
+                    <span class="whitespace-nowrap" x-text="progressLabel()"></span>
+                </div>
+            </div>
+
+            <p x-show="status === 'error' && errorMessage" x-cloak class="text-xs font-semibold text-danger" x-text="errorMessage"></p>
+        </div>
+
+        {{ $slot }}
+    </div>
+</div>

--- a/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
+++ b/resources/views/livewire/recaudo/comunicados/create-run-modal.blade.php
@@ -81,95 +81,21 @@
                                 @foreach ($dataSources as $dataSource)
                                     @php($fileKey = (string) ($dataSource['id'] ?? ''))
                                     @php($selectedFile = $fileKey !== '' ? ($files[$fileKey] ?? null) : null)
-                                    <div
-                                        wire:key="data-source-{{ $dataSource['id'] }}"
-                                        class="grid grid-cols-12 items-start gap-3 py-4 text-sm text-gray-700 dark:text-gray-200"
+
+                                    <x-recaudo.comunicados.data-source-uploader
+                                        :wire:key="'data-source-' . ($dataSource['id'] ?? 'unknown')"
+                                        :data-source="\App\\DTOs\\Recaudo\\Comunicados\\DataSourceUploadDto::fromArray($dataSource)"
+                                        :selected-file="is_array($selectedFile) ? $selectedFile : null"
+                                        :upload-url="route('recaudo.comunicados.uploads.chunk')"
+                                        :chunk-size="(int) config('chunked-uploads.collection_notices.chunk_size')"
+                                        :max-file-size="$this->maxFileSizeBytes"
                                     >
-                                        <!-- Nombre y código -->
-                                        <div class="col-span-12 space-y-1 text-sm tablet:col-span-6 desktop:col-span-6">
-                                            <p class="font-semibold text-gray-900 dark:text-gray-100">
-                                                {{ $dataSource['name'] }} - {{ $dataSource['code'] }}
+                                        @error('files.' . $dataSource['id'])
+                                            <p class="inline-flex items-center rounded-3xl bg-danger px-3 py-1 text-xs font-semibold text-white">
+                                                {{ $message }}
                                             </p>
-                                        </div>
-
-                                        <!-- Tipo archivo -->
-                                        <div class="col-span-12 text-xs uppercase tracking-wide text-gray-600 dark:text-gray-400 tablet:col-span-3 desktop:col-span-3">
-                                            {{ $dataSource['extension'] ? strtoupper($dataSource['extension']) : __('N/A') }}
-                                        </div>
-
-                                        <!-- Uploader -->
-                                        <div class="col-span-12 space-y-2 tablet:col-span-3 desktop:col-span-3">
-                                            <div
-                                                class="space-y-2"
-                                                x-data="collectionRunUploader({
-                                                    dataSourceId: {{ $dataSource['id'] }},
-                                                    uploadUrl: '{{ route('recaudo.comunicados.uploads.chunk') }}',
-                                                    chunkSize: @js((int) config('chunked-uploads.collection_notices.chunk_size')),
-                                                    initialFile: @js(is_array($selectedFile) ? $selectedFile : null),
-                                                    maxFileSize: @js($this->maxFileSizeBytes),
-                                                })"
-                                                x-init="(() => { init(); $el.addEventListener('alpine:destroy', () => destroy(), { once: true }); })()"
-                                                :class="{ 'opacity-60': isUploading }"
-                                                wire:ignore
-                                            >
-                                                <!-- Botón seleccionar -->
-                                                <label
-                                                    for="file-{{ $dataSource['id'] }}"
-                                                    class="inline-flex w-full items-center justify-center gap-2 rounded-3xl border border-primary-300 bg-white px-4 py-2 text-sm font-semibold text-primary-900 shadow-sm transition hover:border-primary-500 hover:bg-primary-200/60 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-offset-2 focus-within:ring-offset-white dark:border-gray-600 dark:bg-gray-900 dark:text-primary-200 dark:focus-within:ring-offset-gray-900 tablet:w-auto"
-                                                    :class="{ 'cursor-not-allowed': isUploading }"
-                                                >
-                                                    <i class="fa-solid fa-upload"></i>
-                                                    <span>{{ __('Seleccionar archivo') }}</span>
-                                                    <input
-                                                        id="file-{{ $dataSource['id'] }}"
-                                                        name="files[{{ $dataSource['id'] }}]"
-                                                        type="file"
-                                                        x-ref="fileInput"
-                                                        @change="handleFileSelected($event)"
-                                                        :disabled="isUploading"
-                                                        class="sr-only"
-                                                    />
-                                                </label>
-
-                                                <button
-                                                    type="button"
-                                                    class="inline-flex w-full items-center justify-center gap-2 rounded-3xl border border-danger bg-white px-4 py-2 text-xs font-semibold text-danger shadow-sm transition hover:bg-danger/10 focus:outline-none focus:ring-2 focus:ring-danger focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:border-danger/60 dark:bg-gray-900 dark:text-danger-200 dark:hover:bg-danger/20 dark:focus:ring-offset-gray-900 tablet:w-auto"
-                                                    x-show="isUploading || status === 'completed'"
-                                                    x-cloak
-                                                    @click="cancelUpload()"
-                                                    :disabled="isUploading && !currentSession"
-                                                >
-                                                    <i :class="isUploading ? 'fa-solid fa-ban' : 'fa-solid fa-xmark'"></i>
-                                                    <span x-text="isUploading ? '{{ __('Cancelar carga') }}' : '{{ __('Quitar archivo') }}'"></span>
-                                                </button>
-
-                                                <!-- Barra de progreso -->
-                                                <div x-show="isUploading" x-cloak class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-                                                    <div
-                                                        class="h-full bg-primary-500 transition-all duration-200 ease-linear"
-                                                        :style="`width: ${progress}%`"
-                                                    ></div>
-                                                </div>
-
-                                                <!-- Nombre solo cuando termine -->
-                                                <div x-show="status === 'completed'" x-cloak>
-                                                    <div class="flex w-full items-center justify-between gap-2 rounded-3xl bg-gray-100 px-3 py-2 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
-                                                        <span class="max-w-[70%] truncate" x-text="fileName"></span>
-                                                        <span class="whitespace-nowrap" x-text="progressLabel()"></span>
-                                                    </div>
-                                                </div>
-
-                                                <!-- Error -->
-                                                <p x-show="status === 'error' && errorMessage" x-cloak class="text-xs font-semibold text-danger" x-text="errorMessage"></p>
-                                            </div>
-
-                                            @error('files.' . $dataSource['id'])
-                                                <p class="inline-flex items-center rounded-3xl bg-danger px-3 py-1 text-xs font-semibold text-white">
-                                                    {{ $message }}
-                                                </p>
-                                            @enderror
-                                        </div>
-                                    </div>
+                                        @enderror
+                                    </x-recaudo.comunicados.data-source-uploader>
                                 @endforeach
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- move the chunked upload UI for comunicados inputs into a reusable Blade component
- introduce a DTO to strongly type data source metadata consumed by the uploader
- wire the modal to the new component while preserving validation, progress feedback, and allowed file formats

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68daf056f500832c86465578943fae2a