### PR TITLE
Add reusable CSV sanitization before COPY ingestion

### DIFF
--- a/app/DTOs/Recaudo/SanitizedCsvResultDto.php
+++ b/app/DTOs/Recaudo/SanitizedCsvResultDto.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTOs\Recaudo;
+
+final readonly class SanitizedCsvResultDto
+{
+    public function __construct(
+        public string $path,
+        public bool $temporary
+    ) {
+    }
+}

--- a/app/Services/Recaudo/CsvSanitizerService.php
+++ b/app/Services/Recaudo/CsvSanitizerService.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Recaudo;
+
+use App\DTOs\Recaudo\SanitizedCsvResultDto;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+final class CsvSanitizerService
+{
+    /**
+     * Columnas esperadas en la tabla por data source.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const COLUMN_MAP = [
+        'BASCAR' => [
+            'run_id',
+            'num_tomador',
+            'fecha_inicio_vig',
+            'valor_total_fact',
+            'periodo',
+            'composite_key',
+            'data',
+            'cantidad_trabajadores',
+            'observacion_trabajadores',
+            'sheet_name',
+        ],
+        'BAPRPO' => [
+            'run_id',
+            'data',
+            'sheet_name',
+        ],
+        'DATPOL' => [
+            'run_id',
+            'data',
+            'sheet_name',
+        ],
+    ];
+
+    /**
+     * @return array<string>
+     */
+    public function getSupportedDataSources(): array
+    {
+        return array_keys(self::COLUMN_MAP);
+    }
+
+    public function supports(string $dataSourceCode): bool
+    {
+        return array_key_exists($dataSourceCode, self::COLUMN_MAP);
+    }
+
+    public function getColumnMap(string $dataSourceCode): array
+    {
+        if (!$this->supports($dataSourceCode)) {
+            throw new RuntimeException('Data source no soportado para mapeo: ' . $dataSourceCode);
+        }
+
+        return self::COLUMN_MAP[$dataSourceCode];
+    }
+
+    public function sanitize(
+        string $originalCsvPath,
+        int $runId,
+        string $dataSourceCode
+    ): SanitizedCsvResultDto {
+        if (!$this->supports($dataSourceCode)) {
+            throw new RuntimeException('Data source no soportado para sanitización: ' . $dataSourceCode);
+        }
+
+        $transformedCsvPath = $originalCsvPath . '.transformed.csv';
+
+        $input = fopen($originalCsvPath, 'rb');
+        if ($input === false) {
+            throw new RuntimeException('No se pudo abrir CSV: ' . $originalCsvPath);
+        }
+
+        $output = fopen($transformedCsvPath, 'wb');
+        if ($output === false) {
+            fclose($input);
+            throw new RuntimeException('No se pudo crear CSV transformado: ' . $transformedCsvPath);
+        }
+
+        $headerLine = fgets($input);
+        if ($headerLine === false) {
+            fclose($input);
+            fclose($output);
+            throw new RuntimeException('CSV sin header: ' . $originalCsvPath);
+        }
+
+        $headers = str_getcsv(rtrim($headerLine, "\r\n"), ';', '"', '');
+
+        $hasSpecificColumns = $dataSourceCode === 'BASCAR';
+        $columnIndex = array_flip($headers);
+
+        if ($hasSpecificColumns) {
+            $this->assertBascarColumns($columnIndex, $originalCsvPath);
+            fwrite($output, implode(';', $this->getColumnMap($dataSourceCode)) . "\n");
+        } else {
+            fwrite($output, 'run_id;data;sheet_name' . "\n");
+        }
+
+        $rowsProcessed = 0;
+        $rowsWithWarnings = [];
+        $currentLine = 1;
+
+        while (($line = fgets($input)) !== false) {
+            $currentLine++;
+            $row = str_getcsv(rtrim($line, "\r\n"), ';', '"', '');
+
+            if ($this->isRowEmpty($row)) {
+                continue;
+            }
+
+            $hadWarning = false;
+
+            if ($hasSpecificColumns) {
+                [$outputRow, $hadWarning] = $this->processBascarRow(
+                    $row,
+                    $headers,
+                    $columnIndex,
+                    $runId,
+                    $hadWarning
+                );
+            } else {
+                [$outputRow, $hadWarning] = $this->processGenericRow(
+                    $row,
+                    $headers,
+                    $runId,
+                    $hadWarning
+                );
+            }
+
+            if ($hadWarning) {
+                $rowsWithWarnings[] = $currentLine;
+            }
+
+            fwrite($output, $this->buildCsvLine($outputRow, $hasSpecificColumns) . "\n");
+            $rowsProcessed++;
+        }
+
+        fclose($input);
+        fclose($output);
+
+        $logData = [
+            'data_source' => $dataSourceCode,
+            'original' => basename($originalCsvPath),
+            'transformed' => basename($transformedCsvPath),
+            'rows_processed' => $rowsProcessed,
+        ];
+
+        if (!empty($rowsWithWarnings)) {
+            $logData['rows_with_backslash_warnings'] = count($rowsWithWarnings);
+            $logData['sample_warning_lines'] = array_slice($rowsWithWarnings, 0, 10);
+
+            Log::warning('⚠️  CSV transformado con advertencias: caracteres saneados', $logData);
+        } else {
+            Log::info('✅ CSV transformado sin advertencias', $logData);
+        }
+
+        return new SanitizedCsvResultDto(
+            path: $transformedCsvPath,
+            temporary: true
+        );
+    }
+
+    /**
+     * @param array<int, string|null> $row
+     */
+    private function isRowEmpty(array $row): bool
+    {
+        foreach ($row as $value) {
+            if ($value !== null && trim((string) $value) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<int, string|null> $row
+     * @param array<int, string> $headers
+     * @param array<string, int> $columnIndex
+     *
+     * @return array{0: array<int, string|null>, 1: bool}
+     */
+    private function processBascarRow(
+        array $row,
+        array $headers,
+        array $columnIndex,
+        int $runId,
+        bool $hadWarning
+    ): array {
+        $jsonData = [];
+
+        foreach ($headers as $index => $header) {
+            $value = $row[$index] ?? null;
+
+            if ($value !== null && is_string($value)) {
+                $sanitized = str_replace('\\', ' ', $value);
+                if ($sanitized !== $value) {
+                    $hadWarning = true;
+                }
+                $value = $sanitized;
+            }
+
+            $jsonData[$header] = $value;
+        }
+
+        $valorTotalIndex = $columnIndex['VALOR_TOTAL_FACT'];
+        $valorTotalValue = $row[$valorTotalIndex] ?? null;
+
+        if ($valorTotalValue !== null) {
+            $valorTotalValue = trim(str_replace('.', '', (string) $valorTotalValue));
+            if ($valorTotalValue === '') {
+                $valorTotalValue = null;
+            }
+        }
+
+        $outputRow = [
+            $runId,
+            $this->sanitizeBackslashes($row[$columnIndex['NUM_TOMADOR']] ?? ''),
+            $this->sanitizeBackslashes($row[$columnIndex['FECHA_INICIO_VIG']] ?? ''),
+            $valorTotalValue,
+            null,
+            null,
+            json_encode($jsonData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            null,
+            null,
+            '',
+        ];
+
+        return [$outputRow, $hadWarning];
+    }
+
+    /**
+     * @param array<int, string|null> $row
+     * @param array<int, string> $headers
+     *
+     * @return array{0: array<int, string|null>, 1: bool}
+     */
+    private function processGenericRow(
+        array $row,
+        array $headers,
+        int $runId,
+        bool $hadWarning
+    ): array {
+        $jsonData = [];
+
+        foreach ($headers as $index => $header) {
+            $value = $row[$index] ?? null;
+
+            if ($value !== null && is_string($value)) {
+                $sanitized = str_replace('\\', ' ', $value);
+                if ($sanitized !== $value) {
+                    $hadWarning = true;
+                }
+                $value = $sanitized;
+            }
+
+            $jsonData[$header] = $value;
+        }
+
+        $outputRow = [
+            $runId,
+            json_encode($jsonData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            '',
+        ];
+
+        return [$outputRow, $hadWarning];
+    }
+
+    /**
+     * @param array<int, string|null> $outputRow
+     */
+    private function buildCsvLine(array $outputRow, bool $hasSpecificColumns): string
+    {
+        $segments = [];
+
+        foreach ($outputRow as $index => $value) {
+            if ($value === null || $value === '') {
+                $segments[] = '';
+                continue;
+            }
+
+            $stringValue = (string) $value;
+            $isJsonField = $hasSpecificColumns ? ($index === 6) : ($index === 1);
+
+            if ($isJsonField) {
+                $segments[] = '"' . str_replace('"', '""', $stringValue) . '"';
+                continue;
+            }
+
+            if (str_contains($stringValue, ';')
+                || str_contains($stringValue, "\n")
+                || str_contains($stringValue, "\r")
+            ) {
+                $segments[] = '"' . str_replace('"', '""', $stringValue) . '"';
+                continue;
+            }
+
+            $segments[] = $stringValue;
+        }
+
+        return implode(';', $segments);
+    }
+
+    /**
+     * @param array<string, int> $columnIndex
+     */
+    private function assertBascarColumns(array $columnIndex, string $originalCsvPath): void
+    {
+        $required = ['NUM_TOMADOR', 'FECHA_INICIO_VIG', 'VALOR_TOTAL_FACT'];
+
+        foreach ($required as $column) {
+            if (!array_key_exists($column, $columnIndex)) {
+                throw new RuntimeException(sprintf(
+                    'CSV BASCAR sin columna requerida "%s" en archivo %s',
+                    $column,
+                    $originalCsvPath
+                ));
+            }
+        }
+    }
+
+    private function sanitizeBackslashes(string $value): string
+    {
+        return str_replace('\\', ' ', $value);
+    }
+}

--- a/app/UseCases/Recaudo/Comunicados/Steps/LoadCsvDataSourcesStep.php
+++ b/app/UseCases/Recaudo/Comunicados/Steps/LoadCsvDataSourcesStep.php
@@ -6,6 +6,8 @@ namespace App\UseCases\Recaudo\Comunicados\Steps;
 
 use App\Contracts\Recaudo\Comunicados\ProcessingStepInterface;
 use App\DTOs\Recaudo\Comunicados\ProcessingContextDto;
+use App\DTOs\Recaudo\SanitizedCsvResultDto;
+use App\Services\Recaudo\CsvSanitizerService;
 use App\Services\Recaudo\PostgreSQLCopyImporter;
 use Illuminate\Contracts\Filesystem\Factory as FilesystemFactory;
 use Illuminate\Support\Facades\DB;
@@ -24,11 +26,6 @@ use RuntimeException;
 final readonly class LoadCsvDataSourcesStep implements ProcessingStepInterface
 {
     /**
-     * Data sources que son CSV y deben cargarse en este paso.
-     */
-    private const CSV_DATA_SOURCES = ['BASCAR', 'BAPRPO', 'DATPOL'];
-
-    /**
      * Mapeo de códigos de data source a tablas PostgreSQL.
      */
     private const TABLE_MAP = [
@@ -37,57 +34,10 @@ final readonly class LoadCsvDataSourcesStep implements ProcessingStepInterface
         'DATPOL' => 'data_source_datpol',
     ];
 
-    /**
-     * Mapeo de data sources a sus columnas en la tabla.
-     * El orden debe coincidir con el orden de columnas en el CSV.
-     */
-    private const COLUMN_MAP = [
-        'BASCAR' => [
-            'run_id',
-            'num_tomador',
-            'fecha_inicio_vig',
-            'valor_total_fact',
-            'periodo',
-            'composite_key',
-            'data',
-            'cantidad_trabajadores',
-            'observacion_trabajadores',
-            'sheet_name',
-        ],
-        'BAPRPO' => [
-            'run_id',
-            'data',
-            'sheet_name',
-        ],
-        'DATPOL' => [
-            'run_id',
-            'data',
-            'sheet_name',
-        ],
-    ];
-
-    /**
-     * Data sources que necesitan transformación CSV→JSON.
-     * BASCAR: Extrae columnas específicas + resto en JSON
-     * BAPRPO, DATPOL: Todo en JSON
-     */
-    private const NEEDS_TRANSFORMATION = ['BASCAR', 'BAPRPO', 'DATPOL'];
-
-    /**
-     * Mapeo de columnas CSV a columnas de tabla para extracción.
-     * Solo para BASCAR que tiene columnas específicas.
-     */
-    private const CSV_COLUMN_EXTRACTION = [
-        'BASCAR' => [
-            'NUM_TOMADOR' => 'num_tomador',
-            'FECHA_INICIO_VIG' => 'fecha_inicio_vig',
-            'VALOR_TOTAL_FACT' => 'valor_total_fact',
-        ],
-    ];
-
     public function __construct(
         private FilesystemFactory $filesystem,
-        private PostgreSQLCopyImporter $copyImporter
+        private PostgreSQLCopyImporter $copyImporter,
+        private CsvSanitizerService $csvSanitizer
     ) {
     }
 
@@ -116,7 +66,7 @@ final readonly class LoadCsvDataSourcesStep implements ProcessingStepInterface
             $extension = strtolower($file->ext ?? '');
 
             // Solo procesar archivos CSV de los data sources especificados
-            if (!in_array($dataSourceCode, self::CSV_DATA_SOURCES, true)) {
+            if (!array_key_exists($dataSourceCode, self::TABLE_MAP)) {
                 // Para Excel, solo guardar metadata (se procesan en otros steps)
                 if (in_array($extension, ['xlsx', 'xls'], true)) {
                     $loadedData[$dataSourceCode] = [
@@ -159,30 +109,37 @@ final readonly class LoadCsvDataSourcesStep implements ProcessingStepInterface
 
             // Transformar CSV si es necesario (BAPRPO, DATPOL)
             $finalCsvPath = $csvPath;
-            if (in_array($dataSourceCode, self::NEEDS_TRANSFORMATION, true)) {
+            $sanitizedResult = null;
+            if ($this->csvSanitizer->supports($dataSourceCode)) {
                 Log::info('🔄 Transformando CSV (columnas→JSON) antes de COPY', [
                     'run_id' => $run->id,
                     'data_source' => $dataSourceCode,
                 ]);
 
-                $finalCsvPath = $this->transformCsvToJsonFormat(
+                $sanitizedResult = $this->csvSanitizer->sanitize(
                     $csvPath,
                     $run->id,
                     $dataSourceCode
                 );
+
+                $finalCsvPath = $sanitizedResult->path;
             }
 
             // Obtener columnas de la tabla
             $columns = $this->getTableColumns($tableName, $dataSourceCode);
 
-            // Importar con PostgreSQL COPY
-            $result = $this->copyImporter->importFromFile(
-                $tableName,
-                $finalCsvPath,
-                $columns,
-                ';', // Delimitador
-                true // Tiene header
-            );
+            try {
+                // Importar con PostgreSQL COPY
+                $result = $this->copyImporter->importFromFile(
+                    $tableName,
+                    $finalCsvPath,
+                    $columns,
+                    ';', // Delimitador
+                    true // Tiene header
+                );
+            } finally {
+                $this->cleanupTemporaryCsv($sanitizedResult);
+            }
 
             $importDuration = (int) ((microtime(true) - $importStart) * 1000);
 
@@ -253,7 +210,7 @@ final readonly class LoadCsvDataSourcesStep implements ProcessingStepInterface
             $dataSourceCode = $file->dataSource->code ?? '';
             $extension = strtolower($file->ext ?? '');
 
-            return in_array($dataSourceCode, self::CSV_DATA_SOURCES, true)
+            return array_key_exists($dataSourceCode, self::TABLE_MAP)
                 && $extension === 'csv';
         });
 
@@ -271,8 +228,8 @@ final readonly class LoadCsvDataSourcesStep implements ProcessingStepInterface
     private function getTableColumns(string $tableName, string $dataSourceCode): array
     {
         // Usar mapeo predefinido si existe
-        if (isset(self::COLUMN_MAP[$dataSourceCode])) {
-            return self::COLUMN_MAP[$dataSourceCode];
+        if ($this->csvSanitizer->supports($dataSourceCode)) {
+            return $this->csvSanitizer->getColumnMap($dataSourceCode);
         }
 
         // Fallback: obtener columnas de la base de datos (excluyendo id y created_at)
@@ -288,213 +245,14 @@ final readonly class LoadCsvDataSourcesStep implements ProcessingStepInterface
         return array_column($columns, 'column_name');
     }
 
-    /**
-     * Transforma un CSV según el tipo de data source.
-     *
-     * - BASCAR: Extrae columnas específicas + resto en JSON
-     * - BAPRPO, DATPOL: Todo en JSON
-     *
-     * @param string $originalCsvPath Ruta del CSV original
-     * @param int $runId Run ID
-     * @param string $dataSourceCode Código del data source
-     *
-     * @return string Ruta del CSV transformado
-     *
-     * @throws RuntimeException
-     */
-    private function transformCsvToJsonFormat(
-        string $originalCsvPath,
-        int $runId,
-        string $dataSourceCode
-    ): string {
-        $transformedCsvPath = $originalCsvPath . '.transformed.csv';
-
-        $input = fopen($originalCsvPath, 'r');
-        if ($input === false) {
-            throw new RuntimeException('No se pudo abrir CSV: ' . $originalCsvPath);
+    private function cleanupTemporaryCsv(?SanitizedCsvResultDto $sanitizedResult): void
+    {
+        if ($sanitizedResult === null) {
+            return;
         }
 
-        $output = fopen($transformedCsvPath, 'w');
-        if ($output === false) {
-            fclose($input);
-            throw new RuntimeException('No se pudo crear CSV transformado: ' . $transformedCsvPath);
+        if ($sanitizedResult->temporary && file_exists($sanitizedResult->path)) {
+            @unlink($sanitizedResult->path);
         }
-
-        // Leer header del CSV original
-        $headerLine = fgets($input);
-        if ($headerLine === false) {
-            fclose($input);
-            fclose($output);
-            throw new RuntimeException('CSV sin header: ' . $originalCsvPath);
-        }
-        $headers = str_getcsv(trim($headerLine), ';', '"', '');
-
-        // Crear índice de columnas
-        $columnIndex = array_flip($headers);
-
-        // Determinar si hay columnas específicas a extraer
-        $hasSpecificColumns = isset(self::CSV_COLUMN_EXTRACTION[$dataSourceCode]);
-        $extraction = self::CSV_COLUMN_EXTRACTION[$dataSourceCode] ?? [];
-
-        // Escribir header del CSV transformado (sin usar fputcsv para evitar backslashes)
-        if ($hasSpecificColumns) {
-            // BASCAR: run_id + columnas específicas + periodo + composite_key + data + cantidad_trabajadores + observacion_trabajadores + sheet_name
-            $headerLine = implode(';', array_values(self::COLUMN_MAP[$dataSourceCode]));
-            fwrite($output, $headerLine . "\n");
-        } else {
-            // BAPRPO, DATPOL: run_id + data + sheet_name
-            fwrite($output, "run_id;data;sheet_name\n");
-        }
-
-        // Procesar cada fila
-        $rowsProcessed = 0;
-        $rowsWithWarnings = [];
-        $currentLine = 1; // +1 por el header
-
-        while (($line = fgets($input)) !== false) {
-            $currentLine++;
-
-            // Usar str_getcsv con escape deshabilitado para evitar problemas con backslashes
-            $row = str_getcsv(trim($line), ';', '"', '');
-
-            // Skip filas vacías (todas las columnas son null o string vacío)
-            // También skip si solo tiene una columna vacía (línea solo con delimitadores)
-            $hasData = false;
-            foreach ($row as $value) {
-                // Considerar solo valores que no sean null, no sean empty string, y no sean solo whitespace
-                if ($value !== null && trim($value) !== '') {
-                    $hasData = true;
-                    break;
-                }
-            }
-            if (!$hasData) {
-                continue; // Saltar fila vacía
-            }
-
-            $hadWarning = false;
-
-            if ($hasSpecificColumns) {
-                // BASCAR: Extraer columnas específicas + todo en JSON
-                $extractedValues = [];
-                $jsonData = [];
-
-                foreach ($headers as $index => $header) {
-                    $value = $row[$index] ?? null;
-
-                    // Sanitizar backslashes que causan problemas con PostgreSQL COPY
-                    if ($value !== null && is_string($value)) {
-                        $originalValue = $value;
-                        // Reemplazar backslashes solitarios con espacio
-                        $value = str_replace('\\', ' ', $value);
-
-                        if ($originalValue !== $value) {
-                            $hadWarning = true;
-                        }
-                    }
-
-                    $jsonData[$header] = $value;
-                }
-
-                // Sanitizar valor numérico: eliminar separadores de miles y espacios
-                $valorTotal = $row[$columnIndex['VALOR_TOTAL_FACT']] ?? null;
-                if ($valorTotal !== null) {
-                    $valorTotal = trim(str_replace('.', '', $valorTotal));
-                    // Si queda vacío después de limpiar, dejarlo como null
-                    if ($valorTotal === '') {
-                        $valorTotal = null;
-                    }
-                }
-
-                // Construir fila: run_id + columnas específicas + periodo + composite_key + data + trabajadores + sheet_name
-                $outputRow = [
-                    $runId,
-                    str_replace('\\', ' ', $row[$columnIndex['NUM_TOMADOR']] ?? ''),
-                    str_replace('\\', ' ', $row[$columnIndex['FECHA_INICIO_VIG']] ?? ''),
-                    $valorTotal, // Valor sanitizado
-                    null, // periodo (se calcula después)
-                    null, // composite_key (se genera después)
-                    json_encode($jsonData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                    null, // cantidad_trabajadores (se calcula después)
-                    null, // observacion_trabajadores (se calcula después)
-                    '', // sheet_name vacío para CSVs
-                ];
-            } else {
-                // BAPRPO, DATPOL: Todo en JSON
-                $jsonData = [];
-                foreach ($headers as $index => $header) {
-                    $value = $row[$index] ?? null;
-
-                    // Sanitizar backslashes
-                    if ($value !== null && is_string($value)) {
-                        $originalValue = $value;
-                        $value = str_replace('\\', ' ', $value);
-
-                        if ($originalValue !== $value) {
-                            $hadWarning = true;
-                        }
-                    }
-
-                    $jsonData[$header] = $value;
-                }
-
-                $outputRow = [
-                    $runId,
-                    json_encode($jsonData, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                    '', // sheet_name vacío para CSVs
-                ];
-            }
-
-            if ($hadWarning) {
-                $rowsWithWarnings[] = $currentLine;
-            }
-
-            // Escribir CSV manualmente para evitar que fputcsv() agregue backslashes
-            // Formato: valor1;valor2;"valor3" (quotes solo cuando necesario)
-            $csvLine = implode(';', array_map(function($value, $index) use ($hasSpecificColumns) {
-                if ($value === null || $value === '') {
-                    return '';
-                }
-                // Convertir a string si es necesario
-                $stringValue = (string) $value;
-
-                // SIEMPRE poner el campo JSON entre quotes (es el campo 'data')
-                $isJsonField = $hasSpecificColumns ? ($index === 6) : ($index === 1);
-
-                if ($isJsonField) {
-                    // JSON siempre va entre quotes, escapando comillas dobles
-                    return '"' . str_replace('"', '""', $stringValue) . '"';
-                }
-
-                // Para otros campos, solo agregar quotes si contiene delimitador o saltos de línea
-                if (strpos($stringValue, ';') !== false || strpos($stringValue, "\n") !== false || strpos($stringValue, "\r") !== false) {
-                    return '"' . str_replace('"', '""', $stringValue) . '"';
-                }
-                return $stringValue;
-            }, $outputRow, array_keys($outputRow)));
-
-            fwrite($output, $csvLine . "\n");
-            $rowsProcessed++;
-        }
-
-        fclose($input);
-        fclose($output);
-
-        $logData = [
-            'data_source' => $dataSourceCode,
-            'original' => basename($originalCsvPath),
-            'transformed' => basename($transformedCsvPath),
-            'rows_processed' => $rowsProcessed,
-        ];
-
-        if (!empty($rowsWithWarnings)) {
-            $logData['rows_with_backslash_warnings'] = count($rowsWithWarnings);
-            $logData['sample_warning_lines'] = array_slice($rowsWithWarnings, 0, 10); // Primeras 10
-
-            Log::warning('⚠️  CSV transformado con advertencias: backslashes reemplazados', $logData);
-        } else {
-            Log::info('✅ CSV transformado sin advertencias', $logData);
-        }
-
-        return $transformedCsvPath;
     }
 }

--- a/tests/Unit/Services/Recaudo/CsvSanitizerServiceTest.php
+++ b/tests/Unit/Services/Recaudo/CsvSanitizerServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Recaudo;
+
+use App\Services\Recaudo\CsvSanitizerService;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class CsvSanitizerServiceTest extends TestCase
+{
+    private CsvSanitizerService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new CsvSanitizerService();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function testSanitizeBascarProducesStableColumnCount(): void
+    {
+        $originalPath = $this->createTemporaryCsv([
+            'NUM_TOMADOR;FECHA_INICIO_VIG;VALOR_TOTAL_FACT;DESCRIPCION;OBS',
+            '0001;2024-01-01;1.234,56;"Valor; con ; separador";"Linea\\con\\backslash"',
+        ]);
+
+        $result = $this->service->sanitize($originalPath, 99, 'BASCAR');
+
+        self::assertTrue($result->temporary);
+        self::assertFileExists($result->path);
+
+        $lines = file($result->path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        self::assertNotFalse($lines);
+        self::assertCount(2, $lines);
+
+        $headerColumns = str_getcsv($lines[0], ';');
+        self::assertCount(10, $headerColumns);
+
+        $dataColumns = str_getcsv($lines[1], ';', '"');
+        self::assertCount(10, $dataColumns);
+
+        $jsonPayload = json_decode($dataColumns[6], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Valor; con ; separador', $jsonPayload['DESCRIPCION']);
+        self::assertSame('Linea con backslash', $jsonPayload['OBS']);
+
+        $this->deleteFiles($originalPath, $result->path);
+    }
+
+    public function testSanitizeGenericDataSourceWrapsEntireRowAsJson(): void
+    {
+        $originalPath = $this->createTemporaryCsv([
+            'CAMPO1;CAMPO2',
+            '"texto;con;delimitador";otro',
+        ]);
+
+        $result = $this->service->sanitize($originalPath, 10, 'BAPRPO');
+
+        $lines = file($result->path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        self::assertNotFalse($lines);
+        self::assertCount(2, $lines);
+
+        self::assertSame('run_id;data;sheet_name', $lines[0]);
+
+        $dataColumns = str_getcsv($lines[1], ';', '"');
+        self::assertSame('10', $dataColumns[0]);
+        $jsonPayload = json_decode($dataColumns[1], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('texto;con;delimitador', $jsonPayload['CAMPO1']);
+        self::assertSame('otro', $jsonPayload['CAMPO2']);
+
+        $this->deleteFiles($originalPath, $result->path);
+    }
+
+    public function testThrowsExceptionWhenRequiredBascarColumnMissing(): void
+    {
+        $originalPath = $this->createTemporaryCsv([
+            'NUM_TOMADOR;FECHA_INICIO_VIG',
+            '0001;2024-01-01',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+
+        try {
+            $this->service->sanitize($originalPath, 5, 'BASCAR');
+        } finally {
+            $this->deleteFiles($originalPath);
+        }
+    }
+
+    private function createTemporaryCsv(array $lines): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'csv_');
+        if ($path === false) {
+            throw new RuntimeException('No se pudo crear archivo temporal de prueba');
+        }
+
+        file_put_contents($path, implode(PHP_EOL, $lines));
+
+        return $path;
+    }
+
+    private function deleteFiles(string ...$paths): void
+    {
+        foreach ($paths as $path) {
+            if ($path !== '' && file_exists($path)) {
+                unlink($path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract a reusable CsvSanitizerService that streams, cleans and maps BASCAR/BAPRPO/DATPOL payloads before COPY
- reuse the sanitizer in the synchronous step and asynchronous job, including deterministic column mapping and temporary file cleanup
- cover the sanitizer with unit tests to guard column counts, JSON integrity and required column detection

## Testing
- composer install --no-interaction --prefer-dist *(fails: CONNECT tunnel 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68e066b80710832c9bd4a7a959f9e603